### PR TITLE
Improve grid aspect ratio handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ Installation
 
 - `NEXT_PUBLIC_PRO_MODE = 1` enables higher quality image storage
 - `NEXT_PUBLIC_PUBLIC_API = 1` enables public API available at `/api`
-- `NEXT_PUBLIC_OG_TEXT_ALIGNMENT = BOTTOM` keeps OG image text bottom aligned (default is top)
 - `NEXT_PUBLIC_HIDE_REPO_LINK = 1` removes footer link to repo
 - `NEXT_PUBLIC_HIDE_FILM_SIMULATIONS = 1` prevents Fujifilm simulations showing up in `/grid` sidebar
+- `NEXT_PUBLIC_GRID_ASPECT_RATIO = 1.5` sets aspect ratio for grid tiles (defaults to `1`—setting to `0` removes the constraint)
+- `NEXT_PUBLIC_OG_TEXT_ALIGNMENT = BOTTOM` keeps OG image text bottom aligned (default is top)
 
 ### Setup alternate storage
 

--- a/src/photo/PhotoDetailPage.tsx
+++ b/src/photo/PhotoDetailPage.tsx
@@ -97,6 +97,7 @@ export default function PhotoDetailPage({
         />}
         contentSide={<div className={cc(
           'grid grid-cols-2',
+          'gap-0.5 sm:gap-1',
           'md:flex md:gap-4',
           'user-select-none',
         )}>

--- a/src/photo/PhotoGrid.tsx
+++ b/src/photo/PhotoGrid.tsx
@@ -7,6 +7,8 @@ import MorePhotos from '@/photo/MorePhotos';
 import { FilmSimulation } from '@/simulation';
 import { GRID_ASPECT_RATIO } from '@/site/config';
 
+const HIGH_DENSITY = GRID_ASPECT_RATIO <= 1;
+
 export default function PhotoGrid({
   photos,
   selectedPhoto,
@@ -41,7 +43,9 @@ export default function PhotoGrid({
           'grid gap-1',
           small
             ? 'grid-cols-3 xs:grid-cols-6'
-            : 'grid-cols-2 sm:grid-cols-4 md:grid-cols-3 lg:grid-cols-4',
+            : HIGH_DENSITY
+              ? 'grid-cols-2 xs:grid-cols-4 lg:grid-cols-5'
+              : 'grid-cols-2 sm:grid-cols-4 md:grid-cols-3 lg:grid-cols-4',
           'items-center',
         )}
         type={animate === false ? 'none' : undefined}

--- a/src/photo/PhotoGrid.tsx
+++ b/src/photo/PhotoGrid.tsx
@@ -5,6 +5,7 @@ import AnimateItems from '@/components/AnimateItems';
 import { Camera } from '@/camera';
 import MorePhotos from '@/photo/MorePhotos';
 import { FilmSimulation } from '@/simulation';
+import { GRID_ASPECT_RATIO } from '@/site/config';
 
 export default function PhotoGrid({
   photos,
@@ -50,14 +51,30 @@ export default function PhotoGrid({
         animateOnFirstLoadOnly={animateOnFirstLoadOnly}
         staggerOnFirstLoadOnly={staggerOnFirstLoadOnly}
         items={photos.map(photo =>
-          <PhotoSmall
+          <div
             key={photo.id}
-            photo={photo}
-            tag={tag}
-            camera={camera}
-            simulation={simulation}
-            selected={photo.id === selectedPhoto?.id}
-          />).concat(additionalTile ?? [])}
+            className={GRID_ASPECT_RATIO !== 0
+              ? cc(
+                'aspect-square',
+                'overflow-hidden',
+                '[&>*]:flex [&>*]:w-full [&>*]:h-full',
+                '[&>*>*]:object-cover',
+              )
+              : undefined}
+            style={{
+              ...GRID_ASPECT_RATIO !== 0 && {
+                aspectRatio: GRID_ASPECT_RATIO ?? 1,
+              },
+            }}
+          >
+            <PhotoSmall {...{
+              photo,
+              tag,
+              camera,
+              simulation,
+              selected: photo.id === selectedPhoto?.id,
+            }} />
+          </div>).concat(additionalTile ?? [])}
       />
       {showMorePath &&
         <MorePhotos path={showMorePath} />}

--- a/src/photo/PhotoGrid.tsx
+++ b/src/photo/PhotoGrid.tsx
@@ -63,7 +63,7 @@ export default function PhotoGrid({
               : undefined}
             style={{
               ...GRID_ASPECT_RATIO !== 0 && {
-                aspectRatio: GRID_ASPECT_RATIO ?? 1,
+                aspectRatio: GRID_ASPECT_RATIO,
               },
             }}
           >

--- a/src/photo/PhotoGrid.tsx
+++ b/src/photo/PhotoGrid.tsx
@@ -40,7 +40,7 @@ export default function PhotoGrid({
     <div className="space-y-4">
       <AnimateItems
         className={cc(
-          'grid gap-1',
+          'grid gap-0.5 sm:gap-1',
           small
             ? 'grid-cols-3 xs:grid-cols-6'
             : HIGH_DENSITY

--- a/src/photo/PhotoGrid.tsx
+++ b/src/photo/PhotoGrid.tsx
@@ -62,7 +62,7 @@ export default function PhotoGrid({
                 'aspect-square',
                 'overflow-hidden',
                 '[&>*]:flex [&>*]:w-full [&>*]:h-full',
-                '[&>*>*]:object-cover',
+                '[&>*>*]:object-cover [&>*>*]:min-h-full',
               )
               : undefined}
             style={{

--- a/src/photo/PhotoLarge.tsx
+++ b/src/photo/PhotoLarge.tsx
@@ -63,6 +63,7 @@ export default function PhotoLarge({
         <div className={cc(
           'sticky top-4 self-start',
           'grid grid-cols-2 md:grid-cols-1',
+          'gap-x-0.5 sm:gap-x-1',
           'gap-y-4',
           '-translate-y-1',
           'mb-4',

--- a/src/site/SiteChecklistClient.tsx
+++ b/src/site/SiteChecklistClient.tsx
@@ -35,6 +35,7 @@ export default function SiteChecklistClient({
   isPublicApiEnabled,
   isOgTextBottomAligned,
   showRefreshButton,
+  gridAspectRatio,
   secret,
 }: ConfigChecklistStatus & {
   showRefreshButton?: boolean
@@ -272,6 +273,17 @@ export default function SiteChecklistClient({
           Set environment variable to {'"1"'} to prevent
           simulations showing up in <code>/grid</code> sidebar:
           {renderEnvVars(['NEXT_PUBLIC_HIDE_FILM_SIMULATIONS'])}
+        </ChecklistRow>
+        <ChecklistRow
+          title={`Grid Aspect Ratio: ${gridAspectRatio}`}
+          status={gridAspectRatio !== 0}
+          isPending={isPendingPage}
+          optional
+        >
+          Set environment variable to any number to enforce aspect ratio
+          {' '}
+          (defaults to {'"1"'}, i.e., square)—set to {'"0"'} to disable:
+          {renderEnvVars(['NEXT_PUBLIC_GRID_ASPECT_RATIO'])}
         </ChecklistRow>
         <ChecklistRow
           title="Legacy OG Text Alignment"

--- a/src/site/config.ts
+++ b/src/site/config.ts
@@ -54,6 +54,9 @@ export const SHOW_FILM_SIMULATIONS =
   process.env.NEXT_PUBLIC_HIDE_FILM_SIMULATIONS !== '1';
 export const OG_TEXT_BOTTOM_ALIGNMENT =
   (process.env.NEXT_PUBLIC_OG_TEXT_ALIGNMENT ?? '').toUpperCase() === 'BOTTOM';
+export const GRID_ASPECT_RATIO = process.env.NEXT_PUBLIC_GRID_ASPECT_RATIO
+  ? parseFloat(process.env.NEXT_PUBLIC_GRID_ASPECT_RATIO)
+  : undefined;
 
 export const CONFIG_CHECKLIST_STATUS = {
   hasPostgres: (process.env.POSTGRES_HOST ?? '').length > 0,

--- a/src/site/config.ts
+++ b/src/site/config.ts
@@ -52,11 +52,11 @@ export const PUBLIC_API_ENABLED = process.env.NEXT_PUBLIC_PUBLIC_API === '1';
 export const SHOW_REPO_LINK = process.env.NEXT_PUBLIC_HIDE_REPO_LINK !== '1';
 export const SHOW_FILM_SIMULATIONS =
   process.env.NEXT_PUBLIC_HIDE_FILM_SIMULATIONS !== '1';
-export const OG_TEXT_BOTTOM_ALIGNMENT =
-  (process.env.NEXT_PUBLIC_OG_TEXT_ALIGNMENT ?? '').toUpperCase() === 'BOTTOM';
 export const GRID_ASPECT_RATIO = process.env.NEXT_PUBLIC_GRID_ASPECT_RATIO
   ? parseFloat(process.env.NEXT_PUBLIC_GRID_ASPECT_RATIO)
-  : undefined;
+  : 1;
+export const OG_TEXT_BOTTOM_ALIGNMENT =
+  (process.env.NEXT_PUBLIC_OG_TEXT_ALIGNMENT ?? '').toUpperCase() === 'BOTTOM';
 
 export const CONFIG_CHECKLIST_STATUS = {
   hasPostgres: (process.env.POSTGRES_HOST ?? '').length > 0,
@@ -75,6 +75,7 @@ export const CONFIG_CHECKLIST_STATUS = {
   isProModeEnabled: PRO_MODE_ENABLED,
   isPublicApiEnabled: PUBLIC_API_ENABLED,
   isOgTextBottomAligned: OG_TEXT_BOTTOM_ALIGNMENT,
+  gridAspectRatio: GRID_ASPECT_RATIO,
 };
 
 export type ConfigChecklistStatus = typeof CONFIG_CHECKLIST_STATUS;


### PR DESCRIPTION
In order to better support heterogeneous photo proportions (i.e., a mix of horizontal + vertical images):
- Standardize on square, cropped photo tiles
- Allow custom aspect ratios via `NEXT_PUBLIC_GRID_ASPECT_RATIO`
- Provide access to legacy behavior where photo tile proportions don't match (`NEXT_PUBLIC_GRID_ASPECT_RATIO = 0`)