### PR TITLE
Streamline photo meta queries

### DIFF
--- a/src/admin/AdminNav.tsx
+++ b/src/admin/AdminNav.tsx
@@ -1,6 +1,6 @@
 import { getStorageUploadUrlsNoStore } from '@/services/storage/cache';
 import {
-  getPhotosCountIncludingHiddenCached,
+  getPhotosMetaCached,
   getPhotosMostRecentUpdateCached,
   getUniqueTagsCached,
 } from '@/photo/cache';
@@ -18,7 +18,9 @@ export default async function AdminNav() {
     countTags,
     mostRecentPhotoUpdateTime,
   ] = await Promise.all([
-    getPhotosCountIncludingHiddenCached().catch(() => 0),
+    getPhotosMetaCached({ hidden: 'include' })
+      .then(({ count }) => count)
+      .catch(() => 0),
     getStorageUploadUrlsNoStore()
       .then(urls => urls.length)
       .catch(e => {

--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -4,7 +4,7 @@ import SiteGrid from '@/components/SiteGrid';
 import AdminUploadsTable from '@/admin/AdminUploadsTable';
 import { PRO_MODE_ENABLED } from '@/site/config';
 import { getStoragePhotoUrlsNoStore } from '@/services/storage/cache';
-import { getPhotos } from '@/photo/db';
+import { getPhotos } from '@/photo/db/query';
 import { revalidatePath } from 'next/cache';
 import AdminPhotosTable from '@/admin/AdminPhotosTable';
 import AdminPhotosTableInfinite from

--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -1,7 +1,6 @@
 import PhotoUpload from '@/photo/PhotoUpload';
 import { clsx } from 'clsx/lite';
 import SiteGrid from '@/components/SiteGrid';
-import { getPhotosCountIncludingHiddenCached } from '@/photo/cache';
 import AdminUploadsTable from '@/admin/AdminUploadsTable';
 import { PRO_MODE_ENABLED } from '@/site/config';
 import { getStoragePhotoUrlsNoStore } from '@/services/storage/cache';
@@ -10,6 +9,7 @@ import { revalidatePath } from 'next/cache';
 import AdminPhotosTable from '@/admin/AdminPhotosTable';
 import AdminPhotosTableInfinite from
   '@/admin/AdminPhotosTableInfinite';
+import { getPhotosMetaCached } from '@/photo/cache';
 
 const DEBUG_PHOTO_BLOBS = false;
 
@@ -27,7 +27,9 @@ export default async function AdminPhotosPage() {
       sortBy: 'createdAt',
       limit: INFINITE_SCROLL_INITIAL_ADMIN_PHOTOS,
     }).catch(() => []),
-    getPhotosCountIncludingHiddenCached().catch(() => 0),
+    getPhotosMetaCached({ hidden: 'include'})
+      .then(({ count }) => count)
+      .catch(() => 0),
     DEBUG_PHOTO_BLOBS
       ? getStoragePhotoUrlsNoStore()
       : [],

--- a/src/app/admin/tags/[tag]/edit/page.tsx
+++ b/src/app/admin/tags/[tag]/edit/page.tsx
@@ -4,7 +4,7 @@ import { getPhotosCached } from '@/photo/cache';
 import TagForm from '@/tag/TagForm';
 import { PATH_ADMIN, PATH_ADMIN_TAGS, pathForTag } from '@/site/paths';
 import PhotoLightbox from '@/photo/PhotoLightbox';
-import { getPhotosTagMeta } from '@/photo/db';
+import { getPhotosMeta } from '@/photo/db';
 import AdminTagBadge from '@/admin/AdminTagBadge';
 
 const MAX_PHOTO_TO_SHOW = 6;
@@ -22,7 +22,7 @@ export default async function PhotoPageEdit({
     { count },
     photos,
   ] = await Promise.all([
-    getPhotosTagMeta(tag),
+    getPhotosMeta({ tag }),
     getPhotosCached({ tag, limit: MAX_PHOTO_TO_SHOW }),
   ]);
 

--- a/src/app/admin/tags/[tag]/edit/page.tsx
+++ b/src/app/admin/tags/[tag]/edit/page.tsx
@@ -4,7 +4,7 @@ import { getPhotosCached } from '@/photo/cache';
 import TagForm from '@/tag/TagForm';
 import { PATH_ADMIN, PATH_ADMIN_TAGS, pathForTag } from '@/site/paths';
 import PhotoLightbox from '@/photo/PhotoLightbox';
-import { getPhotosMeta } from '@/photo/db';
+import { getPhotosMeta } from '@/photo/db/query';
 import AdminTagBadge from '@/admin/AdminTagBadge';
 
 const MAX_PHOTO_TO_SHOW = 6;

--- a/src/app/film/[simulation]/[photoId]/layout.tsx
+++ b/src/app/film/[simulation]/[photoId]/layout.tsx
@@ -14,7 +14,7 @@ import PhotoDetailPage from '@/photo/PhotoDetailPage';
 import { ReactNode, cache } from 'react';
 import { FilmSimulation } from '@/simulation';
 import {
-  getPhotosFilmSimulationMetaCached,
+  getPhotosMetaCached,
   getPhotosNearIdCached,
 } from '@/photo/cache';
 
@@ -70,8 +70,7 @@ export default async function PhotoFilmSimulationPage({
 
   if (!photo) { redirect(PATH_ROOT); }
 
-  const { count, dateRange } =
-    await getPhotosFilmSimulationMetaCached(simulation);
+  const { count, dateRange } = await getPhotosMetaCached({ simulation });
 
   return <>
     {children}

--- a/src/app/grid/page.tsx
+++ b/src/app/grid/page.tsx
@@ -6,7 +6,7 @@ import PhotosEmptyState from '@/photo/PhotosEmptyState';
 import { Metadata } from 'next/types';
 import PhotoGridSidebar from '@/photo/PhotoGridSidebar';
 import { getPhotoSidebarData } from '@/photo/data';
-import { getPhotos } from '@/photo/db';
+import { getPhotos } from '@/photo/db/query';
 import { cache } from 'react';
 import PhotoGridPage from '@/photo/PhotoGridPage';
 import { PATH_GRID } from '@/site/paths';

--- a/src/app/og/page.tsx
+++ b/src/app/og/page.tsx
@@ -2,7 +2,8 @@ import {
   INFINITE_SCROLL_GRID_PHOTO_INITIAL,
   INFINITE_SCROLL_GRID_PHOTO_MULTIPLE,
 } from '@/photo';
-import { getPhotosCached, getPhotosCountCached } from '@/photo/cache';
+import { getPhotosCached } from '@/photo/cache';
+import { getPhotosMeta } from '@/photo/db';
 import StaggeredOgPhotos from '@/photo/StaggeredOgPhotos';
 import StaggeredOgPhotosInfinite from '@/photo/StaggeredOgPhotosInfinite';
 
@@ -12,7 +13,9 @@ export default async function GridPage() {
     count,
   ] = await Promise.all([
     getPhotosCached({ limit: INFINITE_SCROLL_GRID_PHOTO_INITIAL }),
-    getPhotosCountCached(),
+    getPhotosMeta()
+      .then(({ count }) => count)
+      .catch(() => 0),
   ]);
   
   return (

--- a/src/app/og/page.tsx
+++ b/src/app/og/page.tsx
@@ -3,7 +3,7 @@ import {
   INFINITE_SCROLL_GRID_PHOTO_MULTIPLE,
 } from '@/photo';
 import { getPhotosCached } from '@/photo/cache';
-import { getPhotosMeta } from '@/photo/db';
+import { getPhotosMeta } from '@/photo/db/query';
 import StaggeredOgPhotos from '@/photo/StaggeredOgPhotos';
 import StaggeredOgPhotosInfinite from '@/photo/StaggeredOgPhotosInfinite';
 

--- a/src/app/p/[photoId]/image/route.tsx
+++ b/src/app/p/[photoId]/image/route.tsx
@@ -5,7 +5,8 @@ import { getIBMPlexMonoMedium } from '@/site/font';
 import { ImageResponse } from 'next/og';
 import { getImageResponseCacheControlHeaders } from '@/image-response/cache';
 import { IS_PRODUCTION, STATICALLY_OPTIMIZED_OG_IMAGES } from '@/site/config';
-import { GENERATE_STATIC_PARAMS_LIMIT, getPhotoIds } from '@/photo/db';
+import { getPhotoIds } from '@/photo/db/query';
+import { GENERATE_STATIC_PARAMS_LIMIT } from '@/photo/db';
 import { isNextImageReadyBasedOnPhotos } from '@/photo';
 
 export let generateStaticParams:

--- a/src/app/p/[photoId]/layout.tsx
+++ b/src/app/p/[photoId]/layout.tsx
@@ -13,7 +13,8 @@ import {
 import PhotoDetailPage from '@/photo/PhotoDetailPage';
 import { getPhotosNearIdCached } from '@/photo/cache';
 import { IS_PRODUCTION, STATICALLY_OPTIMIZED_PAGES } from '@/site/config';
-import { GENERATE_STATIC_PARAMS_LIMIT, getPhotoIds } from '@/photo/db';
+import { getPhotoIds } from '@/photo/db/query';
+import { GENERATE_STATIC_PARAMS_LIMIT } from '@/photo/db';
 import { ReactNode, cache } from 'react';
 
 const getPhotosNearIdCachedCached = cache((photoId: string) =>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import { Metadata } from 'next/types';
 import { MAX_PHOTOS_TO_SHOW_OG } from '@/image-response';
 import PhotosLarge from '@/photo/PhotosLarge';
 import { cache } from 'react';
-import { getPhotos, getPhotosCount } from '@/photo/db';
+import { getPhotos, getPhotosMeta } from '@/photo/db';
 import PhotosLargeInfinite from '@/photo/PhotosLargeInfinite';
 
 export const dynamic = 'force-static';
@@ -32,7 +32,8 @@ export default async function HomePage() {
       limit: INFINITE_SCROLL_LARGE_PHOTO_INITIAL,
     })
       .catch(() => []),
-    getPhotosCount()
+    getPhotosMeta()
+      .then(({ count }) => count)
       .catch(() => 0),
   ]);
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import { Metadata } from 'next/types';
 import { MAX_PHOTOS_TO_SHOW_OG } from '@/image-response';
 import PhotosLarge from '@/photo/PhotosLarge';
 import { cache } from 'react';
-import { getPhotos, getPhotosMeta } from '@/photo/db';
+import { getPhotos, getPhotosMeta } from '@/photo/db/query';
 import PhotosLargeInfinite from '@/photo/PhotosLargeInfinite';
 
 export const dynamic = 'force-static';

--- a/src/app/shot-on/[make]/[model]/[photoId]/layout.tsx
+++ b/src/app/shot-on/[make]/[model]/[photoId]/layout.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/site/paths';
 import PhotoDetailPage from '@/photo/PhotoDetailPage';
 import {
-  getPhotosCameraMetaCached,
+  getPhotosMetaCached,
   getPhotosNearIdCached,
 } from '@/photo/cache';
 import {
@@ -79,7 +79,7 @@ export default async function PhotoCameraPage({
 
   const camera = cameraFromPhoto(photo, { make, model });
 
-  const { count, dateRange } = await getPhotosCameraMetaCached(camera);
+  const { count, dateRange } = await getPhotosMetaCached({ camera });
 
   return <>
     {children}

--- a/src/app/tag/[tag]/[photoId]/layout.tsx
+++ b/src/app/tag/[tag]/[photoId]/layout.tsx
@@ -11,11 +11,9 @@ import {
   absolutePathForPhotoImage,
 } from '@/site/paths';
 import PhotoDetailPage from '@/photo/PhotoDetailPage';
-import {
-  getPhotosNearIdCached,
-  getPhotosTagMetaCached,
-} from '@/photo/cache';
+import { getPhotosNearIdCached } from '@/photo/cache';
 import { ReactNode, cache } from 'react';
+import { getPhotosMeta } from '@/photo/db';
 
 const getPhotosNearIdCachedCached = cache((photoId: string, tag: string) =>
   getPhotosNearIdCached(
@@ -66,7 +64,7 @@ export default async function PhotoTagPage({
 
   if (!photo) { redirect(PATH_ROOT); }
 
-  const { count, dateRange } = await getPhotosTagMetaCached(tag);
+  const { count, dateRange } = await getPhotosMeta({ tag });
 
   return <>
     {children}

--- a/src/app/tag/[tag]/[photoId]/layout.tsx
+++ b/src/app/tag/[tag]/[photoId]/layout.tsx
@@ -13,7 +13,7 @@ import {
 import PhotoDetailPage from '@/photo/PhotoDetailPage';
 import { getPhotosNearIdCached } from '@/photo/cache';
 import { ReactNode, cache } from 'react';
-import { getPhotosMeta } from '@/photo/db';
+import { getPhotosMeta } from '@/photo/db/query';
 
 const getPhotosNearIdCachedCached = cache((photoId: string, tag: string) =>
   getPhotosNearIdCached(

--- a/src/app/tag/hidden/[photoId]/page.tsx
+++ b/src/app/tag/hidden/[photoId]/page.tsx
@@ -6,8 +6,8 @@ import {
 import PhotoDetailPage from '@/photo/PhotoDetailPage';
 import {
   getPhotosNearIdCached,
-  getPhotosTagHiddenMetaCached,
 } from '@/photo/cache';
+import { getPhotosMeta } from '@/photo/db';
 import { PATH_ROOT, absolutePathForPhoto } from '@/site/paths';
 import { TAG_HIDDEN } from '@/tag';
 import { Metadata } from 'next';
@@ -59,7 +59,7 @@ export default async function PhotoTagHiddenPage({
 
   if (!photo) { redirect(PATH_ROOT); }
 
-  const { count, dateRange } = await getPhotosTagHiddenMetaCached();
+  const { count, dateRange } = await getPhotosMeta({ hidden: 'only' });
 
   return (
     <PhotoDetailPage {...{

--- a/src/app/tag/hidden/[photoId]/page.tsx
+++ b/src/app/tag/hidden/[photoId]/page.tsx
@@ -7,7 +7,7 @@ import PhotoDetailPage from '@/photo/PhotoDetailPage';
 import {
   getPhotosNearIdCached,
 } from '@/photo/cache';
-import { getPhotosMeta } from '@/photo/db';
+import { getPhotosMeta } from '@/photo/db/query';
 import { PATH_ROOT, absolutePathForPhoto } from '@/site/paths';
 import { TAG_HIDDEN } from '@/tag';
 import { Metadata } from 'next';

--- a/src/app/tag/hidden/page.tsx
+++ b/src/app/tag/hidden/page.tsx
@@ -3,7 +3,7 @@ import Banner from '@/components/Banner';
 import SiteGrid from '@/components/SiteGrid';
 import PhotoGrid from '@/photo/PhotoGrid';
 import { getPhotosNoStore } from '@/photo/cache';
-import { getPhotosMeta } from '@/photo/db';
+import { getPhotosMeta } from '@/photo/db/query';
 import { absolutePathForTag } from '@/site/paths';
 import { TAG_HIDDEN, descriptionForTaggedPhotos, titleForTag } from '@/tag';
 import HiddenHeader from '@/tag/HiddenHeader';

--- a/src/app/tag/hidden/page.tsx
+++ b/src/app/tag/hidden/page.tsx
@@ -3,17 +3,18 @@ import Banner from '@/components/Banner';
 import SiteGrid from '@/components/SiteGrid';
 import PhotoGrid from '@/photo/PhotoGrid';
 import { getPhotosNoStore } from '@/photo/cache';
-import { getPhotosTagHiddenMeta } from '@/photo/db';
+import { getPhotosMeta } from '@/photo/db';
 import { absolutePathForTag } from '@/site/paths';
 import { TAG_HIDDEN, descriptionForTaggedPhotos, titleForTag } from '@/tag';
 import HiddenHeader from '@/tag/HiddenHeader';
 import { Metadata } from 'next';
 import { cache } from 'react';
 
-const getPhotosTagHiddenMetaCached = cache(getPhotosTagHiddenMeta);
+const getPhotosHiddenMetaCached = cache(() =>
+  getPhotosMeta({ hidden: 'only' }));
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { count, dateRange } = await getPhotosTagHiddenMetaCached();
+  const { count, dateRange } = await getPhotosHiddenMetaCached();
 
   if (count === 0) { return {}; }
 
@@ -47,7 +48,7 @@ export default async function HiddenTagPage() {
     { count, dateRange },
   ] = await Promise.all([
     getPhotosNoStore({ hidden: 'only' }),
-    getPhotosTagHiddenMetaCached(),
+    getPhotosHiddenMetaCached(),
   ]);
 
   return (

--- a/src/camera/data.ts
+++ b/src/camera/data.ts
@@ -1,7 +1,7 @@
 import { cameraFromPhoto, getCameraFromParams } from '.';
 import {
   getPhotosCached,
-  getPhotosCameraMetaCached,
+  getPhotosMetaCached,
 } from '@/photo/cache';
 
 export const getPhotosCameraDataCached = async (
@@ -12,7 +12,7 @@ export const getPhotosCameraDataCached = async (
   const camera = getCameraFromParams({ make, model });
   return Promise.all([
     getPhotosCached({ camera, limit }),
-    getPhotosCameraMetaCached(camera),
+    getPhotosMetaCached({ camera }),
   ])
     .then(([photos, meta]) => [
       photos,

--- a/src/photo/actions.ts
+++ b/src/photo/actions.ts
@@ -1,7 +1,6 @@
 'use server';
 
 import {
-  GetPhotosOptions,
   deletePhoto,
   insertPhoto,
   deletePhotoTagGlobally,
@@ -9,7 +8,8 @@ import {
   renamePhotoTagGlobally,
   getPhoto,
   getPhotos,
-} from '@/photo/db';
+} from '@/photo/db/query';
+import { GetPhotosOptions } from './db';
 import {
   PhotoFormData,
   convertFormDataToPhotoDbInsert,

--- a/src/photo/actions.ts
+++ b/src/photo/actions.ts
@@ -22,7 +22,7 @@ import {
 } from '@/services/storage';
 import {
   getPhotosCached,
-  getPhotosTagHiddenMetaCached,
+  getPhotosMetaCached,
   revalidateAdminPaths,
   revalidateAllKeysAndPaths,
   revalidatePhoto,
@@ -205,21 +205,20 @@ export const streamAiImageQueryAction = async (
 export const getImageBlurAction = async (url: string) =>
   runAuthenticatedAdminServerAction(() => blurImageFromUrl(url));
 
-export const getPhotosTagHiddenMetaCachedAction = async () =>
-  runAuthenticatedAdminServerAction(getPhotosTagHiddenMetaCached);
+export const getPhotosHiddenMetaCachedAction = async () =>
+  runAuthenticatedAdminServerAction(() =>
+    getPhotosMetaCached({ hidden: 'only' }));
 
 // Public/Private actions
 
 export const getPhotosAction = async (options: GetPhotosOptions) =>
   (options.hidden === 'include' || options.hidden === 'only')
-    ? runAuthenticatedAdminServerAction(() =>
-      getPhotos(options))
+    ? runAuthenticatedAdminServerAction(() => getPhotos(options))
     : getPhotos(options);
 
 export const getPhotosCachedAction = async (options: GetPhotosOptions) =>
   (options.hidden === 'include' || options.hidden === 'only')
-    ? runAuthenticatedAdminServerAction(() =>
-      getPhotosCached (options))
+    ? runAuthenticatedAdminServerAction(() => getPhotosCached (options))
     : getPhotosCached(options);
 
 // Public actions

--- a/src/photo/actions.ts
+++ b/src/photo/actions.ts
@@ -2,11 +2,11 @@
 
 import {
   GetPhotosOptions,
-  sqlDeletePhoto,
-  sqlInsertPhoto,
-  sqlDeletePhotoTagGlobally,
-  sqlUpdatePhoto,
-  sqlRenamePhotoTagGlobally,
+  deletePhoto,
+  insertPhoto,
+  deletePhotoTagGlobally,
+  updatePhoto,
+  renamePhotoTagGlobally,
   getPhoto,
   getPhotos,
 } from '@/photo/db';
@@ -53,7 +53,7 @@ export const createPhotoAction = async (formData: FormData) =>
     
     if (updatedUrl) {
       photo.url = updatedUrl;
-      await sqlInsertPhoto(photo);
+      await insertPhoto(photo);
       revalidateAllKeysAndPaths();
       redirect(PATH_ADMIN_PHOTOS);
     }
@@ -71,7 +71,7 @@ export const updatePhotoAction = async (formData: FormData) =>
       if (url) { photo.url = url; }
     }
 
-    await sqlUpdatePhoto(photo);
+    await updatePhoto(photo);
 
     revalidatePhoto(photo.id);
 
@@ -89,7 +89,7 @@ export const toggleFavoritePhotoAction = async (
       photo.tags = tags.some(tag => tag === TAG_FAVS)
         ? tags.filter(tag => !isTagFavs(tag))
         : [...tags, TAG_FAVS];
-      await sqlUpdatePhoto(convertPhotoToPhotoDbInsert(photo));
+      await updatePhoto(convertPhotoToPhotoDbInsert(photo));
       revalidateAllKeysAndPaths();
       if (shouldRedirect) {
         redirect(pathForPhoto(photoId));
@@ -103,7 +103,7 @@ export const deletePhotoAction = async (
   shouldRedirect?: boolean,
 ) =>
   runAuthenticatedAdminServerAction(async () => {
-    await sqlDeletePhoto(photoId).then(() => deleteStorageUrl(photoUrl));
+    await deletePhoto(photoId).then(() => deleteStorageUrl(photoUrl));
     revalidateAllKeysAndPaths();
     if (shouldRedirect) {
       redirect(PATH_ROOT);
@@ -122,7 +122,7 @@ export const deletePhotoTagGloballyAction = async (formData: FormData) =>
   runAuthenticatedAdminServerAction(async () => {
     const tag = formData.get('tag') as string;
 
-    await sqlDeletePhotoTagGlobally(tag);
+    await deletePhotoTagGlobally(tag);
 
     revalidatePhotosKey();
     revalidateAdminPaths();
@@ -134,7 +134,7 @@ export const renamePhotoTagGloballyAction = async (formData: FormData) =>
     const updatedTag = formData.get('updatedTag') as string;
 
     if (tag && updatedTag && tag !== updatedTag) {
-      await sqlRenamePhotoTagGlobally(tag, updatedTag);
+      await renamePhotoTagGlobally(tag, updatedTag);
       revalidatePhotosKey();
       revalidateTagsKey();
       redirect(PATH_ADMIN_TAGS);
@@ -185,7 +185,7 @@ export const syncPhotoExifDataAction = async (formData: FormData) =>
             ...convertPhotoToFormData(photo),
             ...photoFormExif,
           });
-          await sqlUpdatePhoto(photoFormDbInsert);
+          await updatePhoto(photoFormDbInsert);
           revalidatePhotosKey();
         }
       }

--- a/src/photo/cache.ts
+++ b/src/photo/cache.ts
@@ -12,10 +12,8 @@ import {
   getPhotosCountIncludingHidden,
   getUniqueCameras,
   getUniqueTags,
-  getPhotosCameraMeta,
   getUniqueTagsHidden,
   getUniqueFilmSimulations,
-  getPhotosFilmSimulationMeta,
   getPhotosDateRange,
   getPhotosNearId,
   getPhotosMostRecentUpdate,
@@ -187,18 +185,6 @@ export const getPhotosMostRecentUpdateCached =
   unstable_cache(
     () => getPhotosMostRecentUpdate(),
     [KEY_PHOTOS, KEY_COUNT, KEY_DATE_RANGE],
-  );
-
-export const getPhotosCameraMetaCached =
-  unstable_cache(
-    getPhotosCameraMeta,
-    [KEY_PHOTOS, KEY_CAMERAS, KEY_DATE_RANGE],
-  );
-
-export const getPhotosFilmSimulationMetaCached =
-  unstable_cache(
-    getPhotosFilmSimulationMeta,
-    [KEY_PHOTOS, KEY_FILM_SIMULATIONS, KEY_DATE_RANGE],
   );
 
 export const getPhotoCached = (...args: Parameters<typeof getPhoto>) =>

--- a/src/photo/cache.ts
+++ b/src/photo/cache.ts
@@ -8,13 +8,10 @@ import {
   GetPhotosOptions,
   getPhoto,
   getPhotos,
-  getPhotosCount,
-  getPhotosCountIncludingHidden,
   getUniqueCameras,
   getUniqueTags,
   getUniqueTagsHidden,
   getUniqueFilmSimulations,
-  getPhotosDateRange,
   getPhotosNearId,
   getPhotosMostRecentUpdate,
   getPhotosMeta,
@@ -162,24 +159,6 @@ export const getPhotosMetaCached = (
   getPhotosMeta,
   [KEY_PHOTOS, KEY_COUNT, KEY_DATE_RANGE, ...getPhotosCacheKeys(...args)],
 )(...args);
-
-export const getPhotosDateRangeCached =
-  unstable_cache(
-    getPhotosDateRange,
-    [KEY_PHOTOS, KEY_DATE_RANGE],
-  );
-
-export const getPhotosCountCached =
-  unstable_cache(
-    getPhotosCount,
-    [KEY_PHOTOS, KEY_COUNT],
-  );
-
-export const getPhotosCountIncludingHiddenCached =
-  unstable_cache(
-    getPhotosCountIncludingHidden,
-    [KEY_PHOTOS, KEY_COUNT, KEY_HIDDEN],
-  );
 
 export const getPhotosMostRecentUpdateCached =
   unstable_cache(

--- a/src/photo/cache.ts
+++ b/src/photo/cache.ts
@@ -12,7 +12,6 @@ import {
   getPhotosCountIncludingHidden,
   getUniqueCameras,
   getUniqueTags,
-  getPhotosTagMeta,
   getPhotosCameraMeta,
   getUniqueTagsHidden,
   getUniqueFilmSimulations,
@@ -20,7 +19,7 @@ import {
   getPhotosDateRange,
   getPhotosNearId,
   getPhotosMostRecentUpdate,
-  getPhotosTagHiddenMeta,
+  getPhotosMeta,
 } from '@/photo/db';
 import { parseCachedPhotoDates, parseCachedPhotosDates } from '@/photo';
 import { createCameraKey } from '@/camera';
@@ -159,6 +158,13 @@ export const getPhotosNearIdCached = (
   };
 });
 
+export const getPhotosMetaCached = (
+  ...args: Parameters<typeof getPhotosMeta>
+) => unstable_cache(
+  getPhotosMeta,
+  [KEY_PHOTOS, KEY_COUNT, KEY_DATE_RANGE, ...getPhotosCacheKeys(...args)],
+)(...args);
+
 export const getPhotosDateRangeCached =
   unstable_cache(
     getPhotosDateRange,
@@ -181,18 +187,6 @@ export const getPhotosMostRecentUpdateCached =
   unstable_cache(
     () => getPhotosMostRecentUpdate(),
     [KEY_PHOTOS, KEY_COUNT, KEY_DATE_RANGE],
-  );
-
-export const getPhotosTagMetaCached =
-  unstable_cache(
-    getPhotosTagMeta,
-    [KEY_PHOTOS, KEY_TAGS, KEY_DATE_RANGE],
-  );
-
-export const getPhotosTagHiddenMetaCached =
-  unstable_cache(
-    getPhotosTagHiddenMeta,
-    [KEY_PHOTOS, KEY_TAGS, KEY_HIDDEN, KEY_DATE_RANGE],
   );
 
 export const getPhotosCameraMetaCached =

--- a/src/photo/cache.ts
+++ b/src/photo/cache.ts
@@ -5,7 +5,6 @@ import {
   unstable_noStore,
 } from 'next/cache';
 import {
-  GetPhotosOptions,
   getPhoto,
   getPhotos,
   getUniqueCameras,
@@ -15,7 +14,8 @@ import {
   getPhotosNearId,
   getPhotosMostRecentUpdate,
   getPhotosMeta,
-} from '@/photo/db';
+} from '@/photo/db/query';
+import { GetPhotosOptions } from './db';
 import { parseCachedPhotoDates, parseCachedPhotosDates } from '@/photo';
 import { createCameraKey } from '@/camera';
 import {

--- a/src/photo/data.ts
+++ b/src/photo/data.ts
@@ -9,7 +9,7 @@ import {
   getUniqueCameras,
   getUniqueFilmSimulations,
   getUniqueTags,
-} from '@/photo/db';
+} from '@/photo/db/query';
 import { SHOW_FILM_SIMULATIONS } from '@/site/config';
 import { sortTagsObject } from '@/tag';
 

--- a/src/photo/data.ts
+++ b/src/photo/data.ts
@@ -1,11 +1,11 @@
 import {
-  getPhotosCountCached,
+  getPhotosMetaCached,
   getUniqueCamerasCached,
   getUniqueFilmSimulationsCached,
   getUniqueTagsCached,
 } from '@/photo/cache';
 import {
-  getPhotosCount,
+  getPhotosMeta,
   getUniqueCameras,
   getUniqueFilmSimulations,
   getUniqueTags,
@@ -14,7 +14,9 @@ import { SHOW_FILM_SIMULATIONS } from '@/site/config';
 import { sortTagsObject } from '@/tag';
 
 export const getPhotoSidebarData = () => [
-  getPhotosCount().catch(() => 0),
+  getPhotosMeta()
+    .then(({ count }) => count)
+    .catch(() => 0),
   getUniqueTags().then(sortTagsObject).catch(() => []),
   getUniqueCameras().catch(() => []),
   SHOW_FILM_SIMULATIONS
@@ -23,7 +25,9 @@ export const getPhotoSidebarData = () => [
 ] as const;
 
 export const getPhotoSidebarDataCached = () => [
-  getPhotosCountCached(),
+  getPhotosMetaCached()
+    .then(({ count }) => count)
+    .catch(() => 0),
   getUniqueTagsCached().then(sortTagsObject),
   getUniqueCamerasCached(),
   SHOW_FILM_SIMULATIONS ? getUniqueFilmSimulationsCached() : [],

--- a/src/photo/db.ts
+++ b/src/photo/db.ts
@@ -199,34 +199,6 @@ const sqlGetPhotosDateRange = async () => sql`
     ? rows[0] as PhotoDateRange
     : undefined);
 
-const sqlGetPhotosCameraMeta = async (camera: Camera) => sql`
-  SELECT COUNT(*), MIN(taken_at_naive) as start, MAX(taken_at_naive) as end
-  FROM photos
-  WHERE
-  LOWER(REPLACE(make, ' ', '-'))=${parameterize(camera.make, true)} AND
-  LOWER(REPLACE(model, ' ', '-'))=${parameterize(camera.model, true)} AND
-  hidden IS NOT TRUE
-`.then(({ rows }) => ({
-    count: parseInt(rows[0].count, 10),
-    ...rows[0]?.start && rows[0]?.end
-      ? { dateRange: rows[0] as PhotoDateRange }
-      : undefined,
-  }));
-
-const sqlGetPhotosFilmSimulationMeta = async (
-  simulation: FilmSimulation,
-) => sql`
-  SELECT COUNT(*), MIN(taken_at_naive) as start, MAX(taken_at_naive) as end
-  FROM photos
-  WHERE film_simulation=${simulation} AND
-  hidden IS NOT TRUE
-`.then(({ rows }) => ({
-    count: parseInt(rows[0].count, 10),
-    ...rows[0]?.start && rows[0]?.end
-      ? { dateRange: rows[0] as PhotoDateRange }
-      : undefined,
-  }));
-
 const sqlGetUniqueTags = async () => sql`
   SELECT DISTINCT unnest(tags) as tag, COUNT(*)
   FROM photos
@@ -553,26 +525,12 @@ export const getPhotosMostRecentUpdate = () =>
     'getPhotosMostRecentUpdate',
   );
 
-// TAGS
+// UNIQUE META
 export const getUniqueTags = () =>
   safelyQueryPhotos(sqlGetUniqueTags, 'getUniqueTags');
 export const getUniqueTagsHidden = () =>
   safelyQueryPhotos(sqlGetUniqueTagsHidden, 'getUniqueTagsHidden');
-
-// CAMERAS
 export const getUniqueCameras = () =>
   safelyQueryPhotos(sqlGetUniqueCameras, 'getUniqueCameras');
-export const getPhotosCameraMeta = (camera: Camera) =>
-  safelyQueryPhotos(
-    () => sqlGetPhotosCameraMeta(camera),
-    'getPhotosCameraMeta',
-  );
-
-// FILM SIMULATIONS
 export const getUniqueFilmSimulations = () =>
   safelyQueryPhotos(sqlGetUniqueFilmSimulations, 'getUniqueFilmSimulations');
-export const getPhotosFilmSimulationMeta =
-  (simulation: FilmSimulation) => safelyQueryPhotos(
-    () => sqlGetPhotosFilmSimulationMeta(simulation),
-    'getPhotosFilmSimulationMeta',
-  );

--- a/src/photo/db.ts
+++ b/src/photo/db.ts
@@ -178,26 +178,9 @@ const sqlGetPhoto = (id: string, includeHidden?: boolean) => includeHidden
   // eslint-disable-next-line max-len
   : sql<PhotoDb>`SELECT * FROM photos WHERE id=${id} AND hidden IS NOT TRUE LIMIT 1`;
 
-const sqlGetPhotosCount = async () => sql`
-  SELECT COUNT(*) FROM photos
-  WHERE hidden IS NOT TRUE
-`.then(({ rows }) => parseInt(rows[0].count, 10));
-
-const sqlGetPhotosCountIncludingHidden = async () => sql`
-  SELECT COUNT(*) FROM photos
-`.then(({ rows }) => parseInt(rows[0].count, 10));
-
 const sqlGetPhotosMostRecentUpdate = async () => sql`
   SELECT updated_at FROM photos ORDER BY updated_at DESC LIMIT 1
 `.then(({ rows }) => rows[0] ? rows[0].updated_at as Date : undefined);
-
-const sqlGetPhotosDateRange = async () => sql`
-  SELECT MIN(taken_at_naive) as start, MAX(taken_at_naive) as end
-  FROM photos
-  WHERE hidden IS NOT TRUE
-`.then(({ rows }) => rows[0]?.start && rows[0]?.end
-    ? rows[0] as PhotoDateRange
-    : undefined);
 
 const sqlGetUniqueTags = async () => sql`
   SELECT DISTINCT unnest(tags) as tag, COUNT(*)
@@ -510,15 +493,6 @@ export const getPhoto = async (
     .then(({ rows }) => rows.map(parsePhotoFromDb))
     .then(photos => photos.length > 0 ? photos[0] : undefined);
 };
-export const getPhotosDateRange = () =>
-  safelyQueryPhotos(sqlGetPhotosDateRange, 'getPhotosDateRange');
-export const getPhotosCount = () =>
-  safelyQueryPhotos(sqlGetPhotosCount, 'getPhotosCount');
-export const getPhotosCountIncludingHidden = () =>
-  safelyQueryPhotos(
-    sqlGetPhotosCountIncludingHidden,
-    'getPhotosCountIncludingHidden',
-  );
 export const getPhotosMostRecentUpdate = () =>
   safelyQueryPhotos(
     sqlGetPhotosMostRecentUpdate,

--- a/src/photo/db/index.ts
+++ b/src/photo/db/index.ts
@@ -1,0 +1,116 @@
+import { Camera } from '@/camera';
+import { FilmSimulation } from '@/simulation';
+import { PRIORITY_ORDER_ENABLED } from '@/site/config';
+import { parameterize } from '@/utility/string';
+
+export const GENERATE_STATIC_PARAMS_LIMIT = 1000;
+export const PHOTO_DEFAULT_LIMIT = 100;
+
+export type GetPhotosOptions = {
+  sortBy?: 'createdAt' | 'takenAt' | 'priority';
+  limit?: number;
+  offset?: number;
+  query?: string;
+  tag?: string;
+  camera?: Camera;
+  simulation?: FilmSimulation;
+  takenBefore?: Date;
+  takenAfterInclusive?: Date;
+  hidden?: 'exclude' | 'include' | 'only';
+};
+
+export const getWheresFromOptions = (
+  options: GetPhotosOptions,
+  initialValuesIndex = 1
+) => {
+  const {
+    hidden = 'exclude',
+    takenBefore,
+    takenAfterInclusive,
+    query,
+    tag,
+    camera,
+    simulation,
+  } = options;
+
+  const wheres = [] as string[];
+  const wheresValues = [] as (string | number)[];
+  let valuesIndex = initialValuesIndex;
+
+  switch (hidden) {
+  case 'exclude':
+    wheres.push('hidden IS NOT TRUE');
+    break;
+  case 'only':
+    wheres.push('hidden IS TRUE');
+    break;
+  }
+
+  if (takenBefore) {
+    wheres.push(`taken_at > $${valuesIndex++}`);
+    wheresValues.push(takenBefore.toISOString());
+  }
+  if (takenAfterInclusive) {
+    wheres.push(`taken_at <= $${valuesIndex++}`);
+    wheresValues.push(takenAfterInclusive.toISOString());
+  }
+  if (query) {
+    // eslint-disable-next-line max-len
+    wheres.push(`CONCAT(title, ' ', caption, ' ', semantic_description) ILIKE $${valuesIndex++}`);
+    wheresValues.push(`%${query.toLocaleLowerCase()}%`);
+  }
+  if (tag) {
+    wheres.push(`$${valuesIndex++}=ANY(tags)`);
+    wheresValues.push(tag);
+  }
+  if (camera) {
+    wheres.push(`LOWER(REPLACE(make, ' ', '-'))=$${valuesIndex++}`);
+    wheres.push(`LOWER(REPLACE(model, ' ', '-'))=$${valuesIndex++}`);
+    wheresValues.push(parameterize(camera.make, true));
+    wheresValues.push(parameterize(camera.model, true));
+  }
+  if (simulation) {
+    wheres.push(`film_simulation=$${valuesIndex++}`);
+    wheresValues.push(simulation);
+  }
+
+  return {
+    wheres: wheres.length > 0
+      ? `WHERE ${wheres.join(' AND ')}`
+      : '',
+    wheresValues,
+    lastValuesIndex: valuesIndex,
+  };
+};
+
+export const getOrderByFromOptions = (options: GetPhotosOptions) => {
+  const {
+    sortBy = PRIORITY_ORDER_ENABLED ? 'priority' : 'takenAt',
+  } = options;
+
+  switch (sortBy) {
+  case 'createdAt':
+    return 'ORDER BY created_at DESC';
+  case 'takenAt':
+    return 'ORDER BY taken_at DESC';
+  case 'priority':
+    return 'ORDER BY priority_order ASC, taken_at DESC';
+  }
+};
+
+export const getLimitAndOffsetFromOptions = (
+  options: GetPhotosOptions,
+  initialValuesIndex = 1,
+) => {
+  const {
+    limit = PHOTO_DEFAULT_LIMIT,
+    offset = 0,
+  } = options;
+
+  let valuesIndex = initialValuesIndex;
+
+  return {
+    limitAndOffset: `LIMIT $${valuesIndex++} OFFSET $${valuesIndex++}`,
+    limitAndOffsetValues: [limit, offset],
+  };
+};

--- a/src/simulation/data.ts
+++ b/src/simulation/data.ts
@@ -1,6 +1,6 @@
 import {
   getPhotosCached,
-  getPhotosFilmSimulationMetaCached,
+  getPhotosMetaCached,
 } from '@/photo/cache';
 import { FilmSimulation } from '.';
 
@@ -13,5 +13,5 @@ export const getPhotosFilmSimulationDataCached = ({
 }) =>
   Promise.all([
     getPhotosCached({ simulation, limit }),
-    getPhotosFilmSimulationMetaCached(simulation),
+    getPhotosMetaCached({ simulation }),
   ]);

--- a/src/site/CommandK.tsx
+++ b/src/site/CommandK.tsx
@@ -1,6 +1,6 @@
 import CommandKClient, { CommandKSection } from '@/components/CommandKClient';
 import {
-  getPhotosCountCached,
+  getPhotosMetaCached,
   getUniqueCamerasCached,
   getUniqueFilmSimulationsCached,
   getUniqueTagsCached,
@@ -24,7 +24,9 @@ export default async function CommandK() {
     cameras,
     filmSimulations,
   ] = await Promise.all([
-    getPhotosCountCached().catch(() => 0),
+    getPhotosMetaCached()
+      .then(({ count }) => count)
+      .catch(() => 0),
     getUniqueTagsCached().catch(() => [] as TagsWithMeta),
     getUniqueCamerasCached().catch(() => []),
     SHOW_FILM_SIMULATIONS

--- a/src/state/AppStateProvider.tsx
+++ b/src/state/AppStateProvider.tsx
@@ -7,7 +7,7 @@ import usePathnames from '@/utility/usePathnames';
 import { getAuthAction, logClientAuthUpdate } from '@/auth/actions';
 import useSWR from 'swr';
 import { MATTE_PHOTOS } from '@/site/config';
-import { getPhotosTagHiddenMetaCachedAction } from '@/photo/actions';
+import { getPhotosHiddenMetaCachedAction } from '@/photo/actions';
 
 export default function AppStateProvider({
   children,
@@ -53,7 +53,7 @@ export default function AppStateProvider({
   useEffect(() => {
     if (isUserSignedIn) {
       const timeout = setTimeout(() =>
-        getPhotosTagHiddenMetaCachedAction().then(({ count }) =>
+        getPhotosHiddenMetaCachedAction().then(({ count }) =>
           setHiddenPhotosCount(count))
       , 100);
       return () => clearTimeout(timeout);

--- a/src/tag/data.ts
+++ b/src/tag/data.ts
@@ -1,6 +1,6 @@
 import {
   getPhotosCached,
-  getPhotosTagMetaCached,
+  getPhotosMetaCached,
 } from '@/photo/cache';
 
 export const getPhotosTagDataCached = ({
@@ -12,6 +12,6 @@ export const getPhotosTagDataCached = ({
 }) =>
   Promise.all([
     getPhotosCached({ tag, limit }),
-    getPhotosTagMetaCached(tag),
+    getPhotosMetaCached({ tag }),
   ]);
 


### PR DESCRIPTION
- Create new `sql` primitives to make querying photo meta (count, date ranges, etc.) universal
- Will help support potential new views:
   - `/focal-length/90mm`
   - `/lens/fujifilm/xf90mmf2-r-lm-wr`