### PR TITLE
Fix admin page not displaying all photos

### DIFF
--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -21,7 +21,6 @@ export default async function AdminPhotosPage() {
   ] = await Promise.all([
     getPhotos({
       hidden: 'include',
-      sortBy: 'createdAt',
       limit: INFINITE_SCROLL_INITIAL_ADMIN_PHOTOS,
     }).catch(() => []),
     getPhotosMetaCached({ hidden: 'include'})


### PR DESCRIPTION
The first batch of admin photos queried in order of `created_at DESC`. However, the rest of the photos loaded by infinite scroll are queried in order of `priority_order ASC, taken_at DESC`. As a result, some photos may not be displayed and some photos are displayed twice.

This change would allow all admin photos to be queried in the default order. 