### PR TITLE
Make admin photo queries consistent

### DIFF
--- a/src/admin/AdminPhotosTable.tsx
+++ b/src/admin/AdminPhotosTable.tsx
@@ -91,7 +91,7 @@ export default function AdminPhotosTable({
             )}>
               <PhotoDate {...{
                 photo,
-                dateType: showUpdatedAt ? 'updatedAt' : undefined,
+                dateType: showUpdatedAt ? 'updatedAt' : 'createdAt',
               }} />
             </div>
           </div>

--- a/src/admin/AdminPhotosTableInfinite.tsx
+++ b/src/admin/AdminPhotosTableInfinite.tsx
@@ -21,6 +21,7 @@ export default function AdminPhotosTableInfinite({
       initialOffset={initialOffset}
       itemsPerPage={itemsPerPage}
       useCachedPhotos={false}
+      sortBy="createdAt"
       includeHiddenPhotos
     >
       {({ photos, onLastPhotoVisible, revalidatePhoto }) =>

--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -21,7 +21,6 @@ export default async function AdminPhotosPage() {
   ] = await Promise.all([
     getPhotos({
       hidden: 'include',
-      sortBy: 'createdAt',
       limit: INFINITE_SCROLL_INITIAL_ADMIN_PHOTOS,
     }).catch(() => []),
     getPhotosMetaCached({ hidden: 'include'})

--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -21,6 +21,7 @@ export default async function AdminPhotosPage() {
   ] = await Promise.all([
     getPhotos({
       hidden: 'include',
+      sortBy: 'createdAt',
       limit: INFINITE_SCROLL_INITIAL_ADMIN_PHOTOS,
     }).catch(() => []),
     getPhotosMetaCached({ hidden: 'include'})

--- a/src/photo/InfinitePhotoScroll.tsx
+++ b/src/photo/InfinitePhotoScroll.tsx
@@ -15,6 +15,7 @@ import { clsx } from 'clsx/lite';
 import { useAppState } from '@/state/AppState';
 import { Camera } from '@/camera';
 import { FilmSimulation } from '@/simulation';
+import { GetPhotosOptions } from './db';
 
 export type RevalidatePhoto = (
   photoId: string,
@@ -25,6 +26,7 @@ export default function InfinitePhotoScroll({
   cacheKey,
   initialOffset,
   itemsPerPage,
+  sortBy,
   tag,
   camera,
   simulation,
@@ -35,6 +37,7 @@ export default function InfinitePhotoScroll({
 }: {
   initialOffset: number
   itemsPerPage: number
+  sortBy?: GetPhotosOptions['sortBy']
   tag?: string
   camera?: Camera
   simulation?: FilmSimulation
@@ -59,25 +62,18 @@ export default function InfinitePhotoScroll({
     , [key]);
 
   const fetcher = useCallback(([_key, size]: [string, number]) =>
-    useCachedPhotos
-      ? getPhotosCachedAction({
-        offset: initialOffset + size * itemsPerPage,
-        limit: itemsPerPage,
-        hidden: includeHiddenPhotos ? 'include' : 'exclude',
-        tag,
-        camera,
-        simulation,
-      })
-      : getPhotosAction({
-        offset: initialOffset + size * itemsPerPage,
-        limit: itemsPerPage,
-        hidden: includeHiddenPhotos ? 'include' : 'exclude',
-        tag,
-        camera,
-        simulation,
-      })
+    (useCachedPhotos ? getPhotosCachedAction : getPhotosAction)({
+      offset: initialOffset + size * itemsPerPage,
+      sortBy,
+      limit: itemsPerPage,
+      hidden: includeHiddenPhotos ? 'include' : 'exclude',
+      tag,
+      camera,
+      simulation,
+    })
   , [
     useCachedPhotos,
+    sortBy,
     initialOffset,
     itemsPerPage,
     includeHiddenPhotos,


### PR DESCRIPTION
- Sort both server-side and client-side queries by `createdAt`