### PR TITLE
`next/image` Bypass in Preview

### DIFF
--- a/src/app/admin/photos/[photoId]/edit/page.tsx
+++ b/src/app/admin/photos/[photoId]/edit/page.tsx
@@ -2,7 +2,11 @@ import { redirect } from 'next/navigation';
 import { getPhotoNoStore, getUniqueTagsCached } from '@/photo/cache';
 import { PATH_ADMIN } from '@/site/paths';
 import PhotoEditPageClient from '@/photo/PhotoEditPageClient';
-import { AI_TEXT_GENERATION_ENABLED, BLUR_ENABLED } from '@/site/config';
+import {
+  AI_TEXT_GENERATION_ENABLED,
+  BLUR_ENABLED,
+  IS_PREVIEW,
+} from '@/site/config';
 import { blurImageFromUrl, resizeImageFromUrl } from '@/photo/server';
 import { getNextImageUrlForManipulation } from '@/services/next-image';
 
@@ -21,12 +25,14 @@ export default async function PhotoEditPage({
   
   // Only generate image thumbnails when AI generation is enabled
   const imageThumbnailBase64 = AI_TEXT_GENERATION_ENABLED
-    ? await resizeImageFromUrl(getNextImageUrlForManipulation(photo.url))
+    ? await resizeImageFromUrl(
+      getNextImageUrlForManipulation(photo.url, IS_PREVIEW)
+    )
     : '';
 
   const blurData = BLUR_ENABLED
     ? await blurImageFromUrl(
-      getNextImageUrlForManipulation(photo.url)
+      getNextImageUrlForManipulation(photo.url, IS_PREVIEW)
     )
     : '';
 

--- a/src/image-response/components/ImagePhotoGrid.tsx
+++ b/src/image-response/components/ImagePhotoGrid.tsx
@@ -66,7 +66,8 @@ export default function ImagePhotoGrid({
         >
           <img {...{
             src: getNextImageUrlForRequest(
-              url, nextImageWidth,
+              url,
+              nextImageWidth,
               undefined,
               undefined,
               IS_PREVIEW,

--- a/src/image-response/components/ImagePhotoGrid.tsx
+++ b/src/image-response/components/ImagePhotoGrid.tsx
@@ -5,6 +5,7 @@ import {
   NextImageSize,
   getNextImageUrlForRequest,
 } from '@/services/next-image';
+import { IS_PREVIEW } from '@/site/config';
 
 export default function ImagePhotoGrid({
   photos,
@@ -64,7 +65,12 @@ export default function ImagePhotoGrid({
           }}
         >
           <img {...{
-            src: getNextImageUrlForRequest(url, nextImageWidth),
+            src: getNextImageUrlForRequest(
+              url, nextImageWidth,
+              undefined,
+              undefined,
+              IS_PREVIEW,
+            ),
             style: {
               width: '100%',
               ...imagePosition === 'center' && {

--- a/src/photo/form/PhotoForm.tsx
+++ b/src/photo/form/PhotoForm.tsx
@@ -27,7 +27,7 @@ import usePreventNavigation from '@/utility/usePreventNavigation';
 import { useAppState } from '@/state/AppState';
 import UpdateBlurDataButton from '../UpdateBlurDataButton';
 import { getNextImageUrlForManipulation } from '@/services/next-image';
-import { BLUR_ENABLED } from '@/site/config';
+import { BLUR_ENABLED, IS_PREVIEW } from '@/site/config';
 import { PhotoDbInsert } from '..';
 import ErrorNote from '@/components/ErrorNote';
 
@@ -204,7 +204,7 @@ export default function PhotoForm({
       case 'blurData':
         return shouldDebugImageFallbacks && type === 'edit' && formData.url
           ? <UpdateBlurDataButton
-            photoUrl={getNextImageUrlForManipulation(formData.url)}
+            photoUrl={getNextImageUrlForManipulation(formData.url, IS_PREVIEW)}
             onUpdatedBlurData={blurData =>
               setFormData(data => ({ ...data, blurData }))}
           />

--- a/src/photo/index.ts
+++ b/src/photo/index.ts
@@ -13,6 +13,7 @@ import {
   formatExposureTime,
 } from '@/utility/exif';
 import { parameterize } from '@/utility/string';
+import { fetchBypass } from '@/utility/vercel';
 import camelcaseKeys from 'camelcase-keys';
 import { isBefore } from 'date-fns';
 import type { Metadata } from 'next';
@@ -308,7 +309,9 @@ export const getKeywordsForPhoto = (photo: Photo) =>
     .map(keyword => keyword.toLocaleLowerCase());
 
 export const isNextImageReadyBasedOnPhotos = async (photos: Photo[]) =>
-  photos.length > 0 && fetch(getNextImageUrlForRequest(photos[0].url, 640))
+  photos.length > 0 && fetchBypass(
+    getNextImageUrlForRequest(photos[0].url, 640)
+  )
     .then(response => response.ok)
     .catch(() => false);
 

--- a/src/photo/index.ts
+++ b/src/photo/index.ts
@@ -3,7 +3,7 @@ import { formatFocalLength } from '@/focal';
 import { Lens } from '@/lens';
 import { getNextImageUrlForRequest } from '@/services/next-image';
 import { FilmSimulation } from '@/simulation';
-import { HIGH_DENSITY_GRID, SHOW_EXIF_DATA } from '@/site/config';
+import { HIGH_DENSITY_GRID, IS_PREVIEW, SHOW_EXIF_DATA } from '@/site/config';
 import { ABSOLUTE_PATH_FOR_HOME_IMAGE } from '@/site/paths';
 import { formatDate, formatDateFromPostgresString } from '@/utility/date';
 import {
@@ -13,7 +13,6 @@ import {
   formatExposureTime,
 } from '@/utility/exif';
 import { parameterize } from '@/utility/string';
-import { fetchBypass } from '@/utility/vercel';
 import camelcaseKeys from 'camelcase-keys';
 import { isBefore } from 'date-fns';
 import type { Metadata } from 'next';
@@ -308,10 +307,16 @@ export const getKeywordsForPhoto = (photo: Photo) =>
     .filter(Boolean)
     .map(keyword => keyword.toLocaleLowerCase());
 
-export const isNextImageReadyBasedOnPhotos = async (photos: Photo[]) =>
-  photos.length > 0 && fetchBypass(
-    getNextImageUrlForRequest(photos[0].url, 640)
-  )
+export const isNextImageReadyBasedOnPhotos = async (
+  photos: Photo[],
+): Promise<boolean> =>
+  photos.length > 0 && fetch(getNextImageUrlForRequest(
+    photos[0].url,
+    640,
+    undefined,
+    undefined,
+    IS_PREVIEW,
+  ))
     .then(response => response.ok)
     .catch(() => false);
 

--- a/src/photo/server.ts
+++ b/src/photo/server.ts
@@ -12,7 +12,6 @@ import { PhotoFormData } from './form';
 import { FilmSimulation } from '@/simulation';
 import sharp, { Sharp } from 'sharp';
 import { GEO_PRIVACY_ENABLED, PRO_MODE_ENABLED } from '@/site/config';
-import { fetchBypass } from '@/utility/vercel';
 
 const IMAGE_WIDTH_RESIZE = 200;
 const IMAGE_WIDTH_BLUR = 200;
@@ -129,7 +128,7 @@ const blurImage = async (image: ArrayBuffer) =>
   );
 
 export const resizeImageFromUrl = async (url: string) => 
-  fetchBypass(decodeURIComponent(url))
+  fetch(decodeURIComponent(url))
     .then(res => res.arrayBuffer())
     .then(buffer => resizeImage(buffer))
     .catch(e => {
@@ -138,7 +137,7 @@ export const resizeImageFromUrl = async (url: string) =>
     });
 
 export const blurImageFromUrl = async (url: string) => 
-  fetchBypass(decodeURIComponent(url))
+  fetch(decodeURIComponent(url))
     .then(res => res.arrayBuffer())
     .then(buffer => blurImage(buffer))
     .catch(e => {

--- a/src/photo/server.ts
+++ b/src/photo/server.ts
@@ -12,6 +12,7 @@ import { PhotoFormData } from './form';
 import { FilmSimulation } from '@/simulation';
 import sharp, { Sharp } from 'sharp';
 import { GEO_PRIVACY_ENABLED, PRO_MODE_ENABLED } from '@/site/config';
+import { fetchBypass } from '@/utility/vercel';
 
 const IMAGE_WIDTH_RESIZE = 200;
 const IMAGE_WIDTH_BLUR = 200;
@@ -128,7 +129,7 @@ const blurImage = async (image: ArrayBuffer) =>
   );
 
 export const resizeImageFromUrl = async (url: string) => 
-  fetch(decodeURIComponent(url))
+  fetchBypass(decodeURIComponent(url))
     .then(res => res.arrayBuffer())
     .then(buffer => resizeImage(buffer))
     .catch(e => {
@@ -137,7 +138,7 @@ export const resizeImageFromUrl = async (url: string) =>
     });
 
 export const blurImageFromUrl = async (url: string) => 
-  fetch(decodeURIComponent(url))
+  fetchBypass(decodeURIComponent(url))
     .then(res => res.arrayBuffer())
     .then(buffer => blurImage(buffer))
     .catch(e => {

--- a/src/services/next-image.ts
+++ b/src/services/next-image.ts
@@ -35,5 +35,8 @@ export const getNextImageUrlForRequest = (
 
 // Generate small, low-bandwidth images for quick manipulations such as
 // generating blur data or image thumbnails for AI text generation
-export const getNextImageUrlForManipulation = (imageUrl: string) =>
-  getNextImageUrlForRequest(imageUrl, 640, 90);
+export const getNextImageUrlForManipulation = (
+  imageUrl: string,
+  addBypassSecret = false,
+) =>
+  getNextImageUrlForRequest(imageUrl, 640, 90, undefined, addBypassSecret);

--- a/src/services/next-image.ts
+++ b/src/services/next-image.ts
@@ -1,4 +1,8 @@
-import { BASE_URL } from '@/site/config';
+import {
+  BASE_URL,
+  VERCEL_BYPASS_KEY,
+  VERCEL_BYPASS_SECRET,
+} from '@/site/config';
 
 // Explicity defined next.config.js `imageSizes`
 type NextCustomSize = 200;
@@ -14,12 +18,17 @@ export const getNextImageUrlForRequest = (
   size: NextImageSize,
   quality = 75,
   baseUrl = BASE_URL,
+  addBypassSecret = false,
 ) => {
   const url = new URL(`${baseUrl}/_next/image`);
 
   url.searchParams.append('url', imageUrl);
   url.searchParams.append('w', size.toString());
   url.searchParams.append('q', quality.toString());
+
+  if (addBypassSecret && VERCEL_BYPASS_SECRET) {
+    url.searchParams.append(VERCEL_BYPASS_KEY, VERCEL_BYPASS_SECRET);
+  }
 
   return url.toString();
 };

--- a/src/site/config.ts
+++ b/src/site/config.ts
@@ -35,6 +35,10 @@ export const IS_PRODUCTION = process.env.NODE_ENV === 'production' && (
   !VERCEL_ENV
 );
 
+export const IS_PREVIEW = VERCEL_ENV === 'preview';
+
+export const VERCEL_BYPASS_SECRET = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+
 // User-facing domain, potential site title
 const SITE_DOMAIN =
   process.env.NEXT_PUBLIC_SITE_DOMAIN ||

--- a/src/site/config.ts
+++ b/src/site/config.ts
@@ -37,6 +37,7 @@ export const IS_PRODUCTION = process.env.NODE_ENV === 'production' && (
 
 export const IS_PREVIEW = VERCEL_ENV === 'preview';
 
+export const VERCEL_BYPASS_KEY = 'x-vercel-protection-bypass';
 export const VERCEL_BYPASS_SECRET = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
 
 // User-facing domain, potential site title

--- a/src/utility/useOnVisible.ts
+++ b/src/utility/useOnVisible.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 export default function useOnVisible(
-  ref: React.RefObject<HTMLElement>,
+  ref: React.RefObject<HTMLElement | null>,
   onVisible?: () => void
 ) {
   useEffect(() => {

--- a/src/utility/vercel.ts
+++ b/src/utility/vercel.ts
@@ -1,12 +1,16 @@
-import { IS_PREVIEW, VERCEL_BYPASS_SECRET } from "@/site/config";
+import {
+  IS_PREVIEW,
+  VERCEL_BYPASS_KEY,
+  VERCEL_BYPASS_SECRET,
+} from '@/site/config';
 
 export const fetchBypass: typeof fetch = (url, options) =>
   IS_PREVIEW && VERCEL_BYPASS_SECRET
-  ? fetch(url, {
-    ...options,
-    headers: {
-      ...options?.headers,
-      'x-vercel-protection-bypass': VERCEL_BYPASS_SECRET
-    },
-  })
-  : fetch(url, options);
+    ? fetch(url, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        [VERCEL_BYPASS_KEY]: VERCEL_BYPASS_SECRET,
+      },
+    })
+    : fetch(url, options);

--- a/src/utility/vercel.ts
+++ b/src/utility/vercel.ts
@@ -1,0 +1,12 @@
+import { IS_PREVIEW, VERCEL_BYPASS_SECRET } from "@/site/config";
+
+export const fetchBypass: typeof fetch = (url, options) =>
+  IS_PREVIEW && VERCEL_BYPASS_SECRET
+  ? fetch(url, {
+    ...options,
+    headers: {
+      ...options?.headers,
+      'x-vercel-protection-bypass': VERCEL_BYPASS_SECRET
+    },
+  })
+  : fetch(url, options);

--- a/src/utility/vercel.ts
+++ b/src/utility/vercel.ts
@@ -4,7 +4,7 @@ import {
   VERCEL_BYPASS_SECRET,
 } from '@/site/config';
 
-export const fetchBypass: typeof fetch = (url, options) =>
+export const fetchWithBypass: typeof fetch = (url, options) =>
   IS_PREVIEW && VERCEL_BYPASS_SECRET
     ? fetch(url, {
       ...options,


### PR DESCRIPTION
Use bypass secret when fetching `next/image` urls server-side in preview deployments