### PR TITLE
Mitigate Safari/`viewerjs` zoom bug

### DIFF
--- a/src/components/image/useImageZoomControls.ts
+++ b/src/components/image/useImageZoomControls.ts
@@ -20,14 +20,16 @@ export default function useImageZoomControls(
   useEffect(() => {
     if (imageRef.current && isEnabled) {
       viewerRef.current = new Viewer(imageRef.current, {
-        inline: false,
-        button: true,
         navbar: false,
         title: false,
         toolbar: {
           zoomIn: 1,
           reset: 2,
           zoomOut: 3,
+        },
+        url: (image: HTMLImageElement) => {
+          image.loading = 'eager';
+          return image.src;
         },
         show: () => {
           setShouldRespondToKeyboardCommands?.(false);

--- a/src/photo/PhotosLarge.tsx
+++ b/src/photo/PhotosLarge.tsx
@@ -35,7 +35,6 @@ export default function PhotosLarge({
           onVisible={index === photos.length - 1
             ? onLastPhotoVisible
             : undefined}
-          showZoomControls={false}
         />)}
       itemKeys={photos.map(photo => photo.id)}
     />


### PR DESCRIPTION
Set `image.loading` to "eager" to address safari/`viewerjs` bug, just-in-time before opening loading viewer

- Potentially addressed Safari / `viewerjs` interaction documented here:
- https://github.com/fengyuanchen/viewerjs/issues/650

cc @carlobortolan 