### PR TITLE
Add RSS feed

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -62,6 +62,13 @@ export const metadata: Metadata = {
     type: 'image/png',
     sizes: '180x180',
   }],
+  alternates: {
+    types: {
+      'application/rss+xml': [
+        { url: 'rss.xml', title: 'RSS Feed' },
+      ],
+    },
+  },
 };
 
 export default function RootLayout({

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,0 +1,79 @@
+import { cache } from 'react';
+import { INFINITE_SCROLL_FEED_INITIAL } from '@/photo';
+import { getPhotos } from '@/photo/db/query';
+import { getNextImageUrlForRequest } from '@/platforms/next-image';
+import {
+  BASE_URL,
+  META_DESCRIPTION,
+  META_TITLE,
+} from '@/app/config';
+import { absolutePathForPhoto } from '@/app/paths';
+import { formatDate } from '@/utility/date';
+
+export const dynamic = 'force-static';
+
+const getPhotosCached = cache(() => getPhotos({
+  limit: INFINITE_SCROLL_FEED_INITIAL,
+}));
+
+export async function GET() {
+  const photos = await getPhotosCached().catch(() => []);
+
+  const items = [];
+  for (const photo of photos) {
+    const link = absolutePathForPhoto({photo: photo});
+    const imageWidth = 1080;
+    const imageHeight = Math.round(imageWidth / photo.aspectRatio);
+    const image = getNextImageUrlForRequest(
+      { imageUrl: photo.url, size: imageWidth })
+      .replaceAll('&', '&amp;');
+    const thumbWidth = 640;
+    const thumbHeight = Math.round(thumbWidth / photo.aspectRatio);
+    const thumb = getNextImageUrlForRequest(
+      { imageUrl: photo.url, size: thumbWidth })
+      .replaceAll('&', '&amp;');
+
+    const description = photo.caption ?
+      `<description>
+        <![CDATA[${photo.caption}]]>
+      </description>` : '';
+
+    items.push(`<item>
+      <title>${photo.title}</title>
+      <link>${link}</link>
+      <pubDate>${formatDate({date: photo.createdAt, length: 'rss'})}</pubDate>
+      <guid isPermaLink="true">${link}</guid>
+      ${description}
+      <media:content url="${image}" type="image/jpeg"
+        medium="image" width="${imageWidth}" height="${imageHeight}">
+        <media:thumbnail url="${thumb}"
+          width="${thumbWidth}" height="${thumbHeight}" />
+      </media:content>
+    </item>`);
+  }
+
+  return new Response(
+    `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:media="http://search.yahoo.com/mrss/">
+
+  <channel>
+    <title>${META_TITLE}</title>
+    <atom:link href="${BASE_URL}/rss.xml"
+      rel="self" type="application/rss+xml" />
+    <link>${BASE_URL}</link>
+    <description>${META_DESCRIPTION}</description>
+
+    ${items.join('\n\n    ')}
+
+  </channel>
+
+</rss>`,
+    {
+      headers: {
+        'Content-Type': 'text/xml',
+      },
+    },
+  );
+}

--- a/src/utility/date.ts
+++ b/src/utility/date.ts
@@ -16,12 +16,14 @@ const DATE_STRING_FORMAT_LONG_PLACEHOLDER       = '00 000 0000 00:0000';
 
 const DATE_STRING_FORMAT_POSTGRES               = 'yyyy-MM-dd HH:mm:ss';
 
+const DATE_STRING_FORMAT_RSS                   = 'EEE, dd MMM yyyy HH:mm:ss xx';
+
 export const VALIDATION_EXAMPLE_POSTGRES        = '2025-01-03T21:00:44.000Z';
 export const VALIDATION_EXAMPLE_POSTGRES_NAIVE  = '2025-01-03 16:00:44';
 
 type AmbiguousTimestamp = number | string;
 
-type Length = 'tiny' | 'short' | 'medium' | 'long';
+type Length = 'tiny' | 'short' | 'medium' | 'long' | 'rss';
 
 export const formatDate = ({
   date,
@@ -44,6 +46,9 @@ export const formatDate = ({
     : DATE_STRING_FORMAT_SHORT_PLACEHOLDER;
 
   switch (length) {
+  case 'rss':
+    formatString = DATE_STRING_FORMAT_RSS;
+    break;
   case 'tiny':
     formatString = DATE_STRING_FORMAT_TINY;
     placeholderString = DATE_STRING_FORMAT_TINY_PLACEHOLDER;


### PR DESCRIPTION
I thought it would make sense to have a RSS feed for such a webpage (as the content is also in a feed).

For now I opted for manual string generation as I did not want to introduce additional dependencies (also this is based on the Next.js example). I'm happy to iterate on the actual implementation.

The feed is very simple: title + description and the photo with the creation time (and not the time when photo was taken). For additional information the webpage can be visited.

Here's a screenshot how the Reeder app renders my photos:

<img width="304" alt="Screenshot 2025-04-12 at 19 37 20" src="https://github.com/user-attachments/assets/aad461a5-9f83-42e8-a676-2c1468b94467" />