### PR TITLE
Add support for displaying Nikon Picture Control Names (i.e., Nikon's film recipes)

### DIFF
--- a/__tests__/nikon.test.ts
+++ b/__tests__/nikon.test.ts
@@ -1,0 +1,213 @@
+import {
+  getNikonPictureControlName,
+  isExifForNikon,
+} from '@/platforms/nikon/server';
+import type { ExifData } from 'ts-exif-parser';
+
+describe('Nikon', () => {
+  describe('isExifForNikon', () => {
+    it('identifies Nikon cameras correctly', () => {
+      const nikonExif: ExifData = {
+        tags: { Make: 'NIKON CORPORATION' },
+      } as ExifData;
+
+      const nonNikonExif: ExifData = {
+        tags: { Make: 'Canon' },
+      } as ExifData;
+
+      expect(isExifForNikon(nikonExif)).toBe(true);
+      expect(isExifForNikon(nonNikonExif)).toBe(false);
+    });
+  });
+
+  describe('getNikonPictureControlName', () => {
+    it('extracts PictureControlName from MakerNote data with duplicated version', 
+      () => {
+        // 8 bytes padding, 4 bytes version, 4 bytes version, 20 bytes name
+        const name = 'T&O_BrandonW';
+        const nameBytes = [
+          ...Buffer.from(name, 'ascii'),
+          ...new Array(20 - name.length).fill(0),
+        ];
+        const mockMakerNote = Buffer.from([
+          // 8 bytes padding
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          // "0310"
+          0x30,
+          0x33,
+          0x31,
+          0x30,
+          // "0310"
+          0x30,
+          0x33,
+          0x31,
+          0x30,
+          // 20 bytes name
+          ...nameBytes,
+        ]);
+        const result = getNikonPictureControlName(mockMakerNote);
+        expect(result).toBe('T&O BrandonW');
+      });
+
+    it('extracts PictureControlName from MakerNote data with single version', 
+      () => {
+        // 8 bytes padding, 4 bytes version, 20 bytes name
+        const name = 'Ektar 100';
+        const nameBytes = [
+          ...Buffer.from(name, 'ascii'),
+          ...new Array(20 - name.length).fill(0),
+        ];
+        const mockMakerNote = Buffer.from([
+          // 8 bytes padding
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          // "0310"
+          0x30,
+          0x33,
+          0x31,
+          0x30,
+          // 20 bytes name
+          ...nameBytes,
+        ]);
+        const result = getNikonPictureControlName(mockMakerNote);
+        expect(result).toBe('Ektar 100');
+      });
+
+    it('formats PictureControlName with underscores to proper case', () => {
+      // Test formatting of names with underscores
+      const name = 'FLAT_MONOCHROME';
+      const nameBytes = [
+        ...Buffer.from(name, 'ascii'),
+        ...new Array(20 - name.length).fill(0),
+      ];
+      const mockMakerNote = Buffer.from([
+        // 8 bytes padding
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        // "0310"
+        0x30,
+        0x33,
+        0x31,
+        0x30,
+        // "0310"
+        0x30,
+        0x33,
+        0x31,
+        0x30,
+        // 20 bytes name
+        ...nameBytes,
+      ]);
+      const result = getNikonPictureControlName(mockMakerNote);
+      expect(result).toBe('Flat Monochrome');
+    });
+
+    it('returns undefined when PictureControlData is not found', () => {
+      // Mock MakerNote without PictureControlData
+      const mockMakerNote = Buffer.from([
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+      ]);
+
+      const result = getNikonPictureControlName(mockMakerNote);
+      expect(result).toBeUndefined();
+    });
+
+    it('handles empty or invalid MakerNote data', () => {
+      const emptyBuffer = Buffer.from([]);
+      const result = getNikonPictureControlName(emptyBuffer);
+      expect(result).toBeUndefined();
+    });
+
+    it('ignores version strings that are not followed by valid names', () => {
+      // Version followed by another version (no valid name)
+      const mockMakerNote = Buffer.from([
+        0x30,
+        0x33,
+        0x31,
+        0x30, // "0310" (version)
+        0x30,
+        0x33,
+        0x31,
+        0x30, // "0310" (another version)
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00, // null bytes
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00, // more null bytes
+      ]);
+
+      const result = getNikonPictureControlName(mockMakerNote);
+      expect(result).toBeUndefined();
+    });
+
+    it('formats camelCase and PascalCase names into separate words', () => {
+      const names = [
+        { raw: 'DeepToneMonochrome', expected: 'Deep Tone Monochrome' },
+        { raw: 'KodakGold200', expected: 'Kodak Gold 200' },
+        { raw: 'RichTonePortrait', expected: 'Rich Tone Portrait' },
+        { raw: 'FlatMonochrome', expected: 'Flat Monochrome' },
+      ];
+      for (const { raw, expected } of names) {
+        const nameBytes = [
+          ...Buffer.from(raw, 'ascii'),
+          ...new Array(20 - raw.length).fill(0),
+        ];
+        const mockMakerNote = Buffer.from([
+          // 8 bytes padding
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          // "0310"
+          0x30,
+          0x33,
+          0x31,
+          0x30,
+          // "0310"
+          0x30,
+          0x33,
+          0x31,
+          0x30,
+          // 20 bytes name
+          ...nameBytes,
+        ]);
+        const result = getNikonPictureControlName(mockMakerNote);
+        expect(result).toBe(expected);
+      }
+    });
+  });
+});

--- a/src/photo/form/server.ts
+++ b/src/photo/form/server.ts
@@ -13,7 +13,7 @@ import type { ExifData } from 'ts-exif-parser';
 
 export const convertExifToFormData = (
   data: ExifData,
-  film?: FujifilmSimulation,
+  film?: FujifilmSimulation | string,
   recipeData?: FujifilmRecipe,
 ): Omit<
   Record<keyof PhotoExif, string | undefined>,

--- a/src/platforms/nikon/index.ts
+++ b/src/platforms/nikon/index.ts
@@ -1,0 +1,4 @@
+export const MAKE_NIKON = 'NIKON CORPORATION';
+
+export const isMakeNiken = (make?: string) =>
+  make?.toLocaleUpperCase() === MAKE_NIKON;

--- a/src/platforms/nikon/server.ts
+++ b/src/platforms/nikon/server.ts
@@ -1,0 +1,86 @@
+// MakerNote tag IDs and values referenced from:
+// - exiftool.org/TagNames/Nikon.html
+
+import type { ExifData } from 'ts-exif-parser';
+import { MAKE_NIKON } from '.';
+
+export const isExifForNikon = (data: ExifData) => {
+  return data.tags?.Make?.toLocaleUpperCase() === MAKE_NIKON;
+};
+
+export const getNikonPictureControlName = (
+  bytes: Buffer,
+): string | undefined => {
+  // Start searching after 8 bytes of padding
+  const start = 8;
+
+  // Helper function to format Picture Control Names
+  const formatPictureControlName = (name: string): string => {
+    // If the name is all uppercase (ignoring underscores),
+    // convert to title case
+    const noUnderscore = name.replace(/_/g, '');
+    if (noUnderscore === noUnderscore.toUpperCase()) {
+      return name
+        .replace(/_/g, ' ')
+        .split(' ')
+        .map(
+          (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+        )
+        .join(' ');
+    } else if (!name.includes('_') && !name.includes(' ')) {
+      // If the name is a single word, split camelCase/PascalCase and digits
+      const split = name
+        .replace(/([a-z])([A-Z])/g, '$1 $2') // camelCase or PascalCase
+        .replace(/([A-Za-z])([0-9])/g, '$1 $2') // letters to digits
+        .replace(/([0-9])([A-Za-z])/g, '$1 $2'); // digits to letters
+      return split
+        .split(' ')
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+    } else {
+      // Otherwise, just replace underscores with spaces
+      return name.replace(/_/g, ' ');
+    }
+  };
+
+  // Look for two consecutive version strings (e.g., "0310", "0310")
+  for (let i = start; i <= bytes.length - 28; i++) {
+    const version1 = bytes.slice(i, i + 4).toString('ascii');
+    const version2 = bytes.slice(i + 4, i + 8).toString('ascii');
+    if (/^\d{4}$/.test(version1) && /^\d{4}$/.test(version2)) {
+      const nameBytes = bytes.slice(i + 8, i + 28);
+      const name = nameBytes.toString('ascii').replace(/\0+$/, '').trim();
+      if (
+        name &&
+        name.length > 0 &&
+        name.length <= 20 &&
+        /^[A-Za-z0-9_\s\-&]+$/.test(name) &&
+        !/^\d{4}$/.test(name)
+      ) {
+        return formatPictureControlName(name);
+      }
+    }
+  }
+
+  // Fallback: try to find just a single version followed by name,
+  // but skip if the previous 4 bytes are also a version (to avoid overlap)
+  for (let i = start; i <= bytes.length - 24; i++) {
+    const version = bytes.slice(i, i + 4).toString('ascii');
+    const prevBytes = bytes.slice(i - 4, i).toString('ascii');
+    if (/^\d{4}$/.test(version) && !/^\d{4}$/.test(prevBytes)) {
+      const nameBytes = bytes.slice(i + 4, i + 24);
+      const name = nameBytes.toString('ascii').replace(/\0+$/, '').trim();
+      if (
+        name &&
+        name.length > 0 &&
+        name.length <= 20 &&
+        /^[A-Za-z0-9_\s\-&]+$/.test(name) &&
+        !/^\d{4}$/.test(name)
+      ) {
+        return formatPictureControlName(name);
+      }
+    }
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
Ideally, I would have wanted to support categories for this (Nikon standard recipes, user generated recipes, and Nikon Imaging Cloud recipes), but the exif data doesn't seem to have this information.