### PR TITLE
Update Breakpoint

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -90,7 +90,7 @@ export default function RootLayout({
     >
       <body className={clsx(
         // Center on large screens
-        '3xl:flex flex-col items-center',
+        'lg:flex flex-col items-center',
       )}>
         <AppStateProvider areAdminDebugToolsEnabled={ADMIN_DEBUG_TOOLS_ENABLED}>
           <AppTextProvider>

--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -3,11 +3,10 @@
 import { clsx } from 'clsx/lite';
 import AppGrid from '../components/AppGrid';
 import ThemeSwitcher from '@/app/ThemeSwitcher';
-import Link from 'next/link';
 import { SHOW_REPO_LINK } from '@/app/config';
 import RepoLink from '../components/RepoLink';
 import { usePathname } from 'next/navigation';
-import { PATH_ADMIN_PHOTOS, isPathAdmin, isPathSignIn } from './path';
+import { isPathAdmin, isPathSignIn } from './path';
 import SubmitButtonWithStatus from '@/components/SubmitButtonWithStatus';
 import { signOutAction } from '@/auth/actions';
 import AnimateItems from '@/components/AnimateItems';
@@ -62,9 +61,7 @@ export default function Footer() {
                     ? <Spinner size={16} className="translate-y-[2px]" />
                     : SHOW_REPO_LINK
                       ? <RepoLink />
-                      : <Link href={PATH_ADMIN_PHOTOS}>
-                        {appText.nav.admin}
-                      </Link>}
+                      : ''}
               </div>
               <div className="flex items-center h-10">
                 <ThemeSwitcher />


### PR DESCRIPTION
The original `3xl` break-point to switch to a centered layout for larger screens was not behaving as expected.  This updates this to react to the `lg` break-point instead which does now centre on larger screens.