### PR TITLE
Store optimized assets for all photos

### DIFF
--- a/app/admin/photos/[photoId]/edit/page.tsx
+++ b/app/admin/photos/[photoId]/edit/page.tsx
@@ -13,7 +13,7 @@ import {
   IS_PREVIEW,
 } from '@/app/config';
 import { blurImageFromUrl, resizeImageFromUrl } from '@/photo/server';
-import { getNextImageUrlForManipulation } from '@/platforms/next-image';
+import { getOptimizedPhotoUrlForManipulation } from '@/photo/storage';
 
 export default async function PhotoEditPage({
   params,
@@ -41,13 +41,13 @@ export default async function PhotoEditPage({
   // Only generate image thumbnails when AI generation is enabled
   const imageThumbnailBase64 = AI_CONTENT_GENERATION_ENABLED
     ? await resizeImageFromUrl(
-      getNextImageUrlForManipulation(photo.url, IS_PREVIEW),
+      getOptimizedPhotoUrlForManipulation(photo.url, IS_PREVIEW),
     )
     : '';
 
   const blurData = BLUR_ENABLED
     ? await blurImageFromUrl(
-      getNextImageUrlForManipulation(photo.url, IS_PREVIEW),
+      getOptimizedPhotoUrlForManipulation(photo.url, IS_PREVIEW),
     )
     : '';
 

--- a/app/admin/photos/[photoId]/edit/page.tsx
+++ b/app/admin/photos/[photoId]/edit/page.tsx
@@ -13,11 +13,10 @@ import {
   IS_PREVIEW,
 } from '@/app/config';
 import { blurImageFromUrl, resizeImageFromUrl } from '@/photo/server';
-import { getOptimizedPhotoUrlForManipulation } from '@/photo/storage';
 import {
-  getFileNamePartsFromStorageUrl,
-  getStorageUrlsForPrefix,
-} from '@/platforms/storage';
+  getOptimizedPhotoUrlForManipulation,
+  getStorageUrlsForPhoto,
+} from '@/photo/storage';
 
 export default async function PhotoEditPage({
   params,
@@ -40,9 +39,7 @@ export default async function PhotoEditPage({
 
   if (!photo) { redirect(PATH_ADMIN); }
 
-  const { fileNameBase } = getFileNamePartsFromStorageUrl(photo.url);
-
-  const photoStorageUrls = await getStorageUrlsForPrefix(fileNameBase);
+  const photoStorageUrls = await getStorageUrlsForPhoto(photo);
 
   const hasAiTextGeneration = AI_CONTENT_GENERATION_ENABLED;
   

--- a/app/admin/photos/[photoId]/edit/page.tsx
+++ b/app/admin/photos/[photoId]/edit/page.tsx
@@ -13,11 +13,11 @@ import {
   IS_PREVIEW,
 } from '@/app/config';
 import { blurImageFromUrl, resizeImageFromUrl } from '@/photo/server';
+import { getOptimizedPhotoUrlForManipulation } from '@/photo/storage';
 import {
-  doesPhotoUrlHaveOptimizedFiles,
-  getOptimizedUrlsFromPhotoUrl,
-  getOptimizedPhotoUrlForManipulation,
-} from '@/photo/storage';
+  getFileNamePartsFromStorageUrl,
+  getStorageUrlsForPrefix,
+} from '@/platforms/storage';
 
 export default async function PhotoEditPage({
   params,
@@ -40,9 +40,9 @@ export default async function PhotoEditPage({
 
   if (!photo) { redirect(PATH_ADMIN); }
 
-  const optimizedPhotoUrls = await doesPhotoUrlHaveOptimizedFiles(photo.url)
-    ? getOptimizedUrlsFromPhotoUrl(photo.url)
-    : undefined;
+  const { fileNameBase } = getFileNamePartsFromStorageUrl(photo.url);
+
+  const photoStorageUrls = await getStorageUrlsForPrefix(fileNameBase);
 
   const hasAiTextGeneration = AI_CONTENT_GENERATION_ENABLED;
   
@@ -62,7 +62,7 @@ export default async function PhotoEditPage({
   return (
     <PhotoEditPageClient {...{
       photo,
-      optimizedPhotoUrls,
+      photoStorageUrls,
       uniqueTags,
       uniqueRecipes,
       uniqueFilms,

--- a/app/admin/photos/[photoId]/edit/page.tsx
+++ b/app/admin/photos/[photoId]/edit/page.tsx
@@ -13,7 +13,11 @@ import {
   IS_PREVIEW,
 } from '@/app/config';
 import { blurImageFromUrl, resizeImageFromUrl } from '@/photo/server';
-import { getOptimizedPhotoUrlForManipulation } from '@/photo/storage';
+import {
+  doesPhotoUrlHaveOptimizedFiles,
+  getOptimizedUrlsFromPhotoUrl,
+  getOptimizedPhotoUrlForManipulation,
+} from '@/photo/storage';
 
 export default async function PhotoEditPage({
   params,
@@ -36,6 +40,10 @@ export default async function PhotoEditPage({
 
   if (!photo) { redirect(PATH_ADMIN); }
 
+  const optimizedPhotoUrls = await doesPhotoUrlHaveOptimizedFiles(photo.url)
+    ? getOptimizedUrlsFromPhotoUrl(photo.url)
+    : undefined;
+
   const hasAiTextGeneration = AI_CONTENT_GENERATION_ENABLED;
   
   // Only generate image thumbnails when AI generation is enabled
@@ -54,6 +62,7 @@ export default async function PhotoEditPage({
   return (
     <PhotoEditPageClient {...{
       photo,
+      optimizedPhotoUrls,
       uniqueTags,
       uniqueRecipes,
       uniqueFilms,

--- a/app/api/storage/vercel-blob/route.ts
+++ b/app/api/storage/vercel-blob/route.ts
@@ -4,9 +4,9 @@ import {
   ACCEPTED_PHOTO_FILE_TYPES,
   MAX_PHOTO_UPLOAD_SIZE_IN_BYTES,
 } from '@/photo';
-import { isUploadPathnameValid } from '@/platforms/storage';
 import { handleUpload, type HandleUploadBody } from '@vercel/blob/client';
 import { NextResponse } from 'next/server';
+import { isUploadPathnameValid } from '@/photo/storage';
 
 export async function POST(request: Request): Promise<NextResponse> {
   const body: HandleUploadBody = await request.json();

--- a/src/admin/AdminUploadsTableRow.tsx
+++ b/src/admin/AdminUploadsTableRow.tsx
@@ -11,10 +11,7 @@ import { isElementEntirelyInViewport } from '@/utility/dom';
 import FieldsetWithStatus from '@/components/FieldsetWithStatus';
 import EditButton from './EditButton';
 import AddUploadButton from './AddUploadButton';
-import {
-  getFileNamePartsFromStorageUrl,
-  getIdFromStorageUrl,
-} from '@/platforms/storage';
+import { getFileNamePartsFromStorageUrl } from '@/platforms/storage';
 
 export default function AdminUploadsTableRow({
   url,
@@ -41,8 +38,12 @@ export default function AdminUploadsTableRow({
 }) {
   const ref = useRef<HTMLDivElement>(null);
 
-  const extension = getFileNamePartsFromStorageUrl(url)
-    .fileExtension?.toUpperCase();
+  const {
+    fileExtension,
+    fileId,
+  } = getFileNamePartsFromStorageUrl(url);
+
+  const extension = fileExtension?.toUpperCase();
 
   useEffect(() => {
     if (
@@ -87,7 +88,7 @@ export default function AdminUploadsTableRow({
         'transition-transform',
       )}>
         <ImageMedium
-          title={getIdFromStorageUrl(url)}
+          title={fileId}
           src={url}
           alt={url}
           aspectRatio={3.0 / 2.0}

--- a/src/admin/AdminUploadsTableRow.tsx
+++ b/src/admin/AdminUploadsTableRow.tsx
@@ -3,7 +3,7 @@ import { UrlAddStatus } from './AdminUploadsClient';
 import {
   getExtensionFromStorageUrl,
   getIdFromStorageUrl,
-} from '@/platforms/storage';
+} from '@/photo/storage';
 import clsx from 'clsx/lite';
 import ResponsiveDate from '@/components/ResponsiveDate';
 import Spinner from '@/components/Spinner';

--- a/src/admin/AdminUploadsTableRow.tsx
+++ b/src/admin/AdminUploadsTableRow.tsx
@@ -1,9 +1,5 @@
 import ImageMedium from '@/components/image/ImageMedium';
 import { UrlAddStatus } from './AdminUploadsClient';
-import {
-  getExtensionFromStorageUrl,
-  getIdFromStorageUrl,
-} from '@/photo/storage';
 import clsx from 'clsx/lite';
 import ResponsiveDate from '@/components/ResponsiveDate';
 import Spinner from '@/components/Spinner';
@@ -15,6 +11,10 @@ import { isElementEntirelyInViewport } from '@/utility/dom';
 import FieldsetWithStatus from '@/components/FieldsetWithStatus';
 import EditButton from './EditButton';
 import AddUploadButton from './AddUploadButton';
+import {
+  getFileNamePartsFromStorageUrl,
+  getIdFromStorageUrl,
+} from '@/platforms/storage';
 
 export default function AdminUploadsTableRow({
   url,
@@ -41,7 +41,8 @@ export default function AdminUploadsTableRow({
 }) {
   const ref = useRef<HTMLDivElement>(null);
 
-  const extension = getExtensionFromStorageUrl(url)?.toUpperCase();
+  const extension = getFileNamePartsFromStorageUrl(url)
+    .fileExtension?.toUpperCase();
 
   useEffect(() => {
     if (

--- a/src/app/static.ts
+++ b/src/app/static.ts
@@ -2,6 +2,7 @@ import { CategoryKey } from '../category';
 import {
   CATEGORY_VISIBILITY,
   IS_BUILDING,
+  IS_PRODUCTION,
   STATICALLY_OPTIMIZED_PHOTO_CATEGORIES,
   STATICALLY_OPTIMIZED_PHOTO_CATEGORY_OG_IMAGES,
   STATICALLY_OPTIMIZED_PHOTO_OG_IMAGES,
@@ -21,7 +22,7 @@ const logStaticGenerationDetails = (count: number, content: string) => {
 };
 
 export const staticallyGeneratePhotosIfConfigured = (type: StaticOutput) =>
-  (
+  IS_PRODUCTION && (
     (type === 'page' && STATICALLY_OPTIMIZED_PHOTOS) ||
     (type === 'image' && STATICALLY_OPTIMIZED_PHOTO_OG_IMAGES)
   )
@@ -46,7 +47,8 @@ export const staticallyGenerateCategoryIfConfigured = <T, K>(
   getData: () => Promise<T[]>,
   formatData: (data: T[]) => K[],
 ): (() => Promise<K[]>) | undefined =>
-  CATEGORY_VISIBILITY.includes(key) && (
+  CATEGORY_VISIBILITY.includes(key) &&
+  IS_PRODUCTION && (
     (type === 'page' && STATICALLY_OPTIMIZED_PHOTO_CATEGORIES) ||
     (type === 'image' && STATICALLY_OPTIMIZED_PHOTO_CATEGORY_OG_IMAGES)
   )

--- a/src/app/static.ts
+++ b/src/app/static.ts
@@ -2,7 +2,6 @@ import { CategoryKey } from '../category';
 import {
   CATEGORY_VISIBILITY,
   IS_BUILDING,
-  IS_PRODUCTION,
   STATICALLY_OPTIMIZED_PHOTO_CATEGORIES,
   STATICALLY_OPTIMIZED_PHOTO_CATEGORY_OG_IMAGES,
   STATICALLY_OPTIMIZED_PHOTO_OG_IMAGES,
@@ -22,7 +21,7 @@ const logStaticGenerationDetails = (count: number, content: string) => {
 };
 
 export const staticallyGeneratePhotosIfConfigured = (type: StaticOutput) =>
-  IS_PRODUCTION && (
+  (
     (type === 'page' && STATICALLY_OPTIMIZED_PHOTOS) ||
     (type === 'image' && STATICALLY_OPTIMIZED_PHOTO_OG_IMAGES)
   )
@@ -47,8 +46,7 @@ export const staticallyGenerateCategoryIfConfigured = <T, K>(
   getData: () => Promise<T[]>,
   formatData: (data: T[]) => K[],
 ): (() => Promise<K[]>) | undefined =>
-  CATEGORY_VISIBILITY.includes(key) &&
-  IS_PRODUCTION && (
+  CATEGORY_VISIBILITY.includes(key) && (
     (type === 'page' && STATICALLY_OPTIMIZED_PHOTO_CATEGORIES) ||
     (type === 'image' && STATICALLY_OPTIMIZED_PHOTO_CATEGORY_OG_IMAGES)
   )

--- a/src/components/FieldsetWithStatus.tsx
+++ b/src/components/FieldsetWithStatus.tsx
@@ -41,6 +41,7 @@ export default function FieldsetWithStatus({
   type = 'text',
   inputRef: inputRefProp,
   accessory,
+  footer,
   hideLabel,
   tabIndex,
 }: {
@@ -70,7 +71,8 @@ export default function FieldsetWithStatus({
   capitalize?: boolean
   type?: FieldSetType
   inputRef?: RefObject<HTMLInputElement | null>
-  accessory?: React.ReactNode
+  accessory?: ReactNode
+  footer?: ReactNode
   hideLabel?: boolean
   tabIndex?: number
 }) {
@@ -240,6 +242,9 @@ export default function FieldsetWithStatus({
             {accessory}
           </div>}
         </div>
+        {footer && <div className="mt-3">
+          {footer}
+        </div>}
       </div>
   );
 };

--- a/src/components/SmallDisclosure.tsx
+++ b/src/components/SmallDisclosure.tsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx/lite';
+import { ReactNode, useState } from 'react';
+import { LuChevronRight } from 'react-icons/lu';
+
+export default function SmallDisclosure({
+  label,
+  children,
+}: {
+  label: ReactNode
+  children: ReactNode
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        className={clsx(
+          'flex items-center gap-1.5 link',
+          'hover:opacity-100!',
+        )}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <span className={clsx(
+          'transition-transform duration-200',
+          isOpen && 'rotate-90',
+        )}>
+          <LuChevronRight size={16} />
+        </span>
+        <span>{label}</span>
+      </button>
+      {isOpen &&
+        <div className="pl-5.5">
+          {children}
+        </div>}
+    </div>
+  );
+}

--- a/src/feed/programmatic.ts
+++ b/src/feed/programmatic.ts
@@ -1,8 +1,6 @@
 import { descriptionForPhoto, Photo, titleForPhoto } from '@/photo';
-import {
-  getNextImageUrlForRequest,
-  NextImageSize,
-} from '@/platforms/next-image';
+import { getOptimizedPhotoUrl } from '@/photo/storage';
+import { NextImageSize } from '@/platforms/next-image';
 
 export const FEED_PHOTO_REQUEST_LIMIT = 40;
 
@@ -20,7 +18,7 @@ export const generateFeedMedia = (
   photo: Photo,
   size: NextImageSize,
 ): FeedMedia => ({
-  url: getNextImageUrlForRequest({ imageUrl: photo.url, size }),
+  url: getOptimizedPhotoUrl({ imageUrl: photo.url, size }),
   width: size,
   height: Math.round(size / photo.aspectRatio),
 });

--- a/src/image-response/TagImageResponse.tsx
+++ b/src/image-response/TagImageResponse.tsx
@@ -34,7 +34,7 @@ export default function TagImageResponse({
         height,
         fontFamily,
         icon: isTagFavs(tag)
-          ? <span tw="text-amber-500 inline-flex ">
+          ? <span tw="text-amber-500">
             <IconFavs
               size={height * .066}
               style={{

--- a/src/image-response/components/ImagePhotoGrid.tsx
+++ b/src/image-response/components/ImagePhotoGrid.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable jsx-a11y/alt-text */
 
 import { Photo } from '@/photo';
-import {
-  NextImageSize,
-  getNextImageUrlForRequest,
-} from '@/platforms/next-image';
+import { NextImageSize } from '@/platforms/next-image';
 import { IS_PREVIEW } from '@/app/config';
+import {
+  doAllPhotosHaveOptimizedFiles,
+  getOptimizedPhotoUrl,
+} from '@/photo/storage';
 
-export default function ImagePhotoGrid({
+export default async function ImagePhotoGrid({
   photos,
   width,
   widthArbitrary,
@@ -47,6 +48,8 @@ export default function ImagePhotoGrid({
   const cellHeight= height / rows -
     (rows - 1) * gap / rows;
 
+  const doOptimizedFilesExist = await doAllPhotosHaveOptimizedFiles(photos);
+
   return (
     <div
       style={{
@@ -69,10 +72,11 @@ export default function ImagePhotoGrid({
           }}
         >
           <img {...{
-            src: getNextImageUrlForRequest({
+            src: getOptimizedPhotoUrl({
               imageUrl: url,
               size: nextImageWidth,
               addBypassSecret: IS_PREVIEW,
+              compatibilityMode: !doOptimizedFilesExist,
             }),
             style: {
               ...imageStyle,

--- a/src/photo/PhotoEditPageClient.tsx
+++ b/src/photo/PhotoEditPageClient.tsx
@@ -18,6 +18,7 @@ import { Films } from '@/film';
 
 export default function PhotoEditPageClient({
   photo,
+  optimizedPhotoUrls,
   uniqueTags,
   uniqueRecipes,
   uniqueFilms,
@@ -26,6 +27,7 @@ export default function PhotoEditPageClient({
   blurData,
 }: {
   photo: Photo
+  optimizedPhotoUrls?: string[]
   uniqueTags: Tags
   uniqueRecipes: Recipes
   uniqueFilms: Films
@@ -77,6 +79,7 @@ export default function PhotoEditPageClient({
       <PhotoForm
         type="edit"
         initialPhotoForm={photoForm}
+        optimizedPhotoUrls={optimizedPhotoUrls}
         updatedExifData={updatedExifData}
         updatedBlurData={blurData}
         uniqueTags={uniqueTags}

--- a/src/photo/PhotoEditPageClient.tsx
+++ b/src/photo/PhotoEditPageClient.tsx
@@ -15,10 +15,11 @@ import ExifCaptureButton from '@/admin/ExifCaptureButton';
 import { useState } from 'react';
 import { Recipes } from '@/recipe';
 import { Films } from '@/film';
+import { StorageListResponse } from '@/platforms/storage';
 
 export default function PhotoEditPageClient({
   photo,
-  optimizedPhotoUrls,
+  photoStorageUrls,
   uniqueTags,
   uniqueRecipes,
   uniqueFilms,
@@ -27,7 +28,7 @@ export default function PhotoEditPageClient({
   blurData,
 }: {
   photo: Photo
-  optimizedPhotoUrls?: string[]
+  photoStorageUrls?: StorageListResponse
   uniqueTags: Tags
   uniqueRecipes: Recipes
   uniqueFilms: Films
@@ -79,7 +80,7 @@ export default function PhotoEditPageClient({
       <PhotoForm
         type="edit"
         initialPhotoForm={photoForm}
-        optimizedPhotoUrls={optimizedPhotoUrls}
+        photoStorageUrls={photoStorageUrls}
         updatedExifData={updatedExifData}
         updatedBlurData={blurData}
         uniqueTags={uniqueTags}

--- a/src/photo/PhotoUploadWithStatus.tsx
+++ b/src/photo/PhotoUploadWithStatus.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { uploadPhotoFromClient } from '@/platforms/storage';
 import { usePathname, useRouter } from 'next/navigation';
 import { PATH_ADMIN_UPLOADS, pathForAdminUploadUrl } from '@/app/path';
 import ImageInput from '../components/ImageInput';
@@ -10,6 +9,7 @@ import { RefObject, useTransition, useRef, useEffect } from 'react';
 import Spinner from '@/components/Spinner';
 import ResponsiveText from '@/components/primitives/ResponsiveText';
 import { useAppText } from '@/i18n/state/client';
+import { uploadPhotoFromClient } from './storage/client';
 
 export default function PhotoUploadWithStatus({
   inputRef,

--- a/src/photo/PhotoUploadWithStatus.tsx
+++ b/src/photo/PhotoUploadWithStatus.tsx
@@ -9,7 +9,7 @@ import { RefObject, useTransition, useRef, useEffect } from 'react';
 import Spinner from '@/components/Spinner';
 import ResponsiveText from '@/components/primitives/ResponsiveText';
 import { useAppText } from '@/i18n/state/client';
-import { uploadPhotoFromClient } from './storage/client';
+import { uploadPhotoFromClient } from './storage';
 
 export default function PhotoUploadWithStatus({
   inputRef,

--- a/src/photo/actions.ts
+++ b/src/photo/actions.ts
@@ -58,7 +58,7 @@ import {
 } from '@/app/config';
 import { generateAiImageQueries } from './ai/server';
 import { createStreamableValue } from '@ai-sdk/rsc';
-import { convertUploadToPhoto } from './storage';
+import { convertUploadToPhoto } from './storage/server';
 import { UrlAddStatus } from '@/admin/AdminUploadsClient';
 import { convertStringToArray } from '@/utility/string';
 import { after } from 'next/server';

--- a/src/photo/actions.ts
+++ b/src/photo/actions.ts
@@ -1,7 +1,6 @@
 'use server';
 
 import {
-  deletePhoto,
   insertPhoto,
   deletePhotoTagGlobally,
   updatePhoto,
@@ -43,6 +42,7 @@ import {
 import {
   blurImageFromUrl,
   convertFormDataToPhotoDbInsertAndLookupRecipeTitle,
+  deletePhotoAndFiles,
   extractImageDataFromBlobPath,
   propagateRecipeTitleIfNecessary,
 } from './server';
@@ -356,7 +356,7 @@ export const deletePhotosAction = async (photoIds: string[]) =>
     for (const photoId of photoIds) {
       const photo = await getPhoto(photoId, true);
       if (photo) {
-        await deletePhoto(photoId).then(() => deleteFile(photo.url));
+        await deletePhotoAndFiles(photoId, photo.url);
       }
     }
     revalidateAllKeysAndPaths();
@@ -368,7 +368,7 @@ export const deletePhotoAction = async (
   shouldRedirect?: boolean,
 ) =>
   runAuthenticatedAdminServerAction(async () => {
-    await deletePhoto(photoId).then(() => deleteFile(photoUrl));
+    await deletePhotoAndFiles(photoId, photoUrl);
     revalidateAllKeysAndPaths();
     if (shouldRedirect) {
       redirect(PATH_ROOT);

--- a/src/photo/actions.ts
+++ b/src/photo/actions.ts
@@ -78,7 +78,7 @@ export const createPhotoAction = async (formData: FormData) =>
     );
 
     const updatedUrl = await convertUploadToPhoto({
-      urlOrigin: photo.url,
+      uploadUrl: photo.url,
       shouldStripGpsData,
     });
     
@@ -174,7 +174,7 @@ const addUpload = async ({
     onStreamUpdate?.('Transferring to photo storage');
 
     const updatedUrl = await convertUploadToPhoto({
-      urlOrigin: url,
+      uploadUrl: url,
       fileBytes,
       shouldStripGpsData,
     });
@@ -284,7 +284,7 @@ export const updatePhotoAction = async (formData: FormData) =>
       // Anonymize storage url on update if necessary by
       // re-running image upload transfer logic
       const url = await convertUploadToPhoto({
-        urlOrigin: photo.url,
+        uploadUrl: photo.url,
         shouldDeleteOrigin: false,
       });
       if (url) {
@@ -515,7 +515,7 @@ export const syncPhotoAction = async (photoId: string, isBatch?: boolean) =>
           // Anonymize storage url on update if necessary by
           // re-running image upload transfer logic
           const url = await convertUploadToPhoto({
-            urlOrigin: photo.url,
+            uploadUrl: photo.url,
             fileBytes,
             shouldStripGpsData,
             shouldDeleteOrigin: false,

--- a/src/photo/color/server.ts
+++ b/src/photo/color/server.ts
@@ -1,5 +1,4 @@
 import { convertRgbToOklab, parseHex } from 'culori';
-import { getNextImageUrlForManipulation } from '@/platforms/next-image';
 import {
   AI_CONTENT_GENERATION_ENABLED,
   IS_PREVIEW,
@@ -11,6 +10,7 @@ import { extractColors } from 'extract-colors';
 import { getImageBase64FromUrl } from '../server';
 import { generateOpenAiImageQuery } from '@/platforms/openai';
 import { calculateColorSort } from './sort';
+import { getOptimizedPhotoUrlForManipulation } from '../storage';
 
 const NULL_RGB = { r: 0, g: 0, b: 0 };
 
@@ -29,7 +29,7 @@ export const convertHexToOklch = (hex: string): Oklch => {
 
 // Convert image url to byte array
 const getImageDataFromUrl = async (_url: string) => {
-  const url = getNextImageUrlForManipulation(_url, IS_PREVIEW);
+  const url = getOptimizedPhotoUrlForManipulation(_url, IS_PREVIEW);
   const imageBuffer = await fetch(decodeURIComponent(url))
     .then(res => res.arrayBuffer());
   const image = sharp(imageBuffer);
@@ -121,7 +121,7 @@ export const getColorFromAI = async (
   _url: string,
   useBatch?: boolean,
 ) => {
-  const url = getNextImageUrlForManipulation(_url, IS_PREVIEW);
+  const url = getOptimizedPhotoUrlForManipulation(_url, IS_PREVIEW);
   const image = await getImageBase64FromUrl(url);
   const hexColor = await generateOpenAiImageQuery(image, `
     Does this image have a primary subject color?

--- a/src/photo/form/PhotoForm.tsx
+++ b/src/photo/form/PhotoForm.tsx
@@ -56,12 +56,14 @@ import AnchorSections from '@/components/AnchorSections';
 import useIsVisible from '@/utility/useIsVisible';
 import useHash from '@/utility/useHash';
 import { getOptimizedPhotoUrlForManipulation } from '../storage';
+import { getFileNamePartsFromStorageUrl } from '@/platforms/storage';
 
 const THUMBNAIL_SIZE = 300;
 
 export default function PhotoForm({
   type = 'create',
   initialPhotoForm,
+  optimizedPhotoUrls,
   updatedExifData,
   updatedBlurData,
   uniqueTags,
@@ -75,6 +77,7 @@ export default function PhotoForm({
 }: {
   type?: 'create' | 'edit'
   initialPhotoForm: Partial<PhotoFormData>
+  optimizedPhotoUrls?: string[]
   updatedExifData?: Partial<PhotoFormData>
   updatedBlurData?: string
   uniqueTags?: Tags
@@ -550,6 +553,28 @@ export default function PhotoForm({
                           key={key}
                           {...fieldProps}
                         />;
+                      case 'url':
+                        return <div
+                          key={key}
+                          className="flex flex-col gap-2"
+                        >
+                          <FieldsetWithStatus {...fieldProps} />
+                          {optimizedPhotoUrls && formData.url && <div>
+                            {[formData.url, ...optimizedPhotoUrls].map(url => {
+                              const {
+                                fileName,
+                              } = getFileNamePartsFromStorageUrl(url);
+                              return <Link
+                                key={url}
+                                className="block"
+                                href={url}
+                                target="_blank"
+                              >
+                                {fileName}
+                              </Link>;
+                            })}
+                          </div>}
+                        </div>;
                       default:
                         return <FieldsetWithStatus
                           key={key}

--- a/src/photo/form/PhotoForm.tsx
+++ b/src/photo/form/PhotoForm.tsx
@@ -36,7 +36,6 @@ import Spinner from '@/components/Spinner';
 import usePreventNavigation from '@/utility/usePreventNavigation';
 import { useAppState } from '@/app/AppState';
 import UpdateBlurDataButton from '../UpdateBlurDataButton';
-import { getNextImageUrlForManipulation } from '@/platforms/next-image';
 import { BLUR_ENABLED, IS_PREVIEW } from '@/app/config';
 import ErrorNote from '@/components/ErrorNote';
 import { convertRecipesForForm, Recipes } from '@/recipe';
@@ -56,6 +55,7 @@ import { capitalize } from '@/utility/string';
 import AnchorSections from '@/components/AnchorSections';
 import useIsVisible from '@/utility/useIsVisible';
 import useHash from '@/utility/useHash';
+import { getOptimizedPhotoUrlForManipulation } from '../storage';
 
 const THUMBNAIL_SIZE = 300;
 
@@ -245,7 +245,7 @@ export default function PhotoForm({
         case 'blurData':
           return shouldDebugImageFallbacks && type === 'edit' && formData.url
             ? <UpdateBlurDataButton
-              photoUrl={getNextImageUrlForManipulation(
+              photoUrl={getOptimizedPhotoUrlForManipulation(
                 formData.url,
                 IS_PREVIEW,
               )}

--- a/src/photo/form/PhotoForm.tsx
+++ b/src/photo/form/PhotoForm.tsx
@@ -57,6 +57,7 @@ import useIsVisible from '@/utility/useIsVisible';
 import useHash from '@/utility/useHash';
 import { getOptimizedPhotoUrlForManipulation } from '../storage';
 import { getFileNamePartsFromStorageUrl } from '@/platforms/storage';
+import SmallDisclosure from '@/components/SmallDisclosure';
 
 const THUMBNAIL_SIZE = 300;
 
@@ -257,6 +258,31 @@ export default function PhotoForm({
             />
             : null;
       }
+    }
+  };
+
+  const footerForField = (key: keyof PhotoFormData) => {
+    switch (key) {
+      case 'url':
+        return optimizedPhotoUrls && formData.url
+          ? <SmallDisclosure label="Optimized file set">
+            <div className="space-y-1">
+              {[formData.url, ...optimizedPhotoUrls].map(url => {
+                const {
+                  fileName,
+                } = getFileNamePartsFromStorageUrl(url);
+                return <Link
+                  key={url}
+                  className="block text-medium"
+                  href={url}
+                  target="_blank"
+                >
+                  {fileName}
+                </Link>;
+              })}
+            </div>
+          </SmallDisclosure>
+          : undefined;
     }
   };
 
@@ -503,6 +529,7 @@ export default function PhotoForm({
                       ),
                       type,
                       accessory: accessoryForField(key),
+                      footer: footerForField(key),
                     };
                     switch (key) {
                       case 'film':
@@ -553,28 +580,6 @@ export default function PhotoForm({
                           key={key}
                           {...fieldProps}
                         />;
-                      case 'url':
-                        return <div
-                          key={key}
-                          className="flex flex-col gap-2"
-                        >
-                          <FieldsetWithStatus {...fieldProps} />
-                          {optimizedPhotoUrls && formData.url && <div>
-                            {[formData.url, ...optimizedPhotoUrls].map(url => {
-                              const {
-                                fileName,
-                              } = getFileNamePartsFromStorageUrl(url);
-                              return <Link
-                                key={url}
-                                className="block"
-                                href={url}
-                                target="_blank"
-                              >
-                                {fileName}
-                              </Link>;
-                            })}
-                          </div>}
-                        </div>;
                       default:
                         return <FieldsetWithStatus
                           key={key}

--- a/src/photo/form/PhotoForm.tsx
+++ b/src/photo/form/PhotoForm.tsx
@@ -56,15 +56,19 @@ import AnchorSections from '@/components/AnchorSections';
 import useIsVisible from '@/utility/useIsVisible';
 import useHash from '@/utility/useHash';
 import { getOptimizedPhotoUrlForManipulation } from '../storage';
-import { getFileNamePartsFromStorageUrl } from '@/platforms/storage';
+import {
+  getFileNamePartsFromStorageUrl,
+  StorageListResponse,
+} from '@/platforms/storage';
 import SmallDisclosure from '@/components/SmallDisclosure';
+import { TbPhoto } from 'react-icons/tb';
 
 const THUMBNAIL_SIZE = 300;
 
 export default function PhotoForm({
   type = 'create',
   initialPhotoForm,
-  optimizedPhotoUrls,
+  photoStorageUrls,
   updatedExifData,
   updatedBlurData,
   uniqueTags,
@@ -78,7 +82,7 @@ export default function PhotoForm({
 }: {
   type?: 'create' | 'edit'
   initialPhotoForm: Partial<PhotoFormData>
-  optimizedPhotoUrls?: string[]
+  photoStorageUrls?: StorageListResponse
   updatedExifData?: Partial<PhotoFormData>
   updatedBlurData?: string
   uniqueTags?: Tags
@@ -264,21 +268,24 @@ export default function PhotoForm({
   const footerForField = (key: keyof PhotoFormData) => {
     switch (key) {
       case 'url':
-        return optimizedPhotoUrls && formData.url
+        return photoStorageUrls && photoStorageUrls.length > 1
           ? <SmallDisclosure label="Optimized file set">
             <div className="space-y-1">
-              {[formData.url, ...optimizedPhotoUrls].map(url => {
-                const {
-                  fileName,
-                } = getFileNamePartsFromStorageUrl(url);
-                return <Link
+              {photoStorageUrls.map(({ url, size }) => {
+                const { fileName } = getFileNamePartsFromStorageUrl(url);
+                return <div
                   key={url}
-                  className="block text-medium"
-                  href={url}
-                  target="_blank"
+                  className="flex items-center gap-2"
                 >
-                  {fileName}
-                </Link>;
+                  <TbPhoto className="translate-y-[1px] text-medium" />
+                  <Link
+                    href={url}
+                    target="_blank"
+                  >
+                    {fileName}
+                  </Link>
+                  <span className="text-dim">{size}</span>
+                </div>;
               })}
             </div>
           </SmallDisclosure>

--- a/src/photo/server.ts
+++ b/src/photo/server.ts
@@ -33,7 +33,7 @@ import exifr from 'exifr';
 
 const IMAGE_WIDTH_BLUR = 200;
 const IMAGE_WIDTH_RESIZE_SMALL = 200;
-const IMAGE_WIDTH_RESIZE_LARGE = 640;
+const IMAGE_WIDTH_RESIZE_LARGE = 1080;
 
 export const extractImageDataFromBlobPath = async (
   blobPath: string,

--- a/src/photo/server.ts
+++ b/src/photo/server.ts
@@ -1,5 +1,6 @@
 import {
   deleteFile,
+  getIdFromStorageUrl,
 } from '@/platforms/storage';
 import { convertFormDataToPhotoDbInsert } from '@/photo/form';
 import {
@@ -28,7 +29,7 @@ import { convertExifToFormData } from './form/server';
 import { getColorFieldsForPhotoForm } from './color/server';
 import exifr from 'exifr';
 import { getOptimizedFileNamesFromUrl } from './storage/server';
-import { getExtensionFromStorageUrl, getIdFromStorageUrl } from './storage';
+import { getFileNamePartsFromPhotoUrl } from './storage';
 
 const IMAGE_WIDTH_BLUR = 200;
 const IMAGE_WIDTH_RESIZE_SM = 200;
@@ -60,7 +61,7 @@ export const extractImageDataFromBlobPath = async (
 
   const blobId = getIdFromStorageUrl(url);
 
-  const extension = getExtensionFromStorageUrl(url);
+  const extension = getFileNamePartsFromPhotoUrl(url).fileExtension;
 
   let exifData: ExifData | undefined;
   let exifrData: any | undefined;

--- a/src/photo/server.ts
+++ b/src/photo/server.ts
@@ -1,5 +1,6 @@
 import {
   deleteFile,
+  getFileNamePartsFromStorageUrl,
   getIdFromStorageUrl,
 } from '@/platforms/storage';
 import { convertFormDataToPhotoDbInsert } from '@/photo/form';
@@ -28,8 +29,7 @@ import { PhotoDbInsert } from '.';
 import { convertExifToFormData } from './form/server';
 import { getColorFieldsForPhotoForm } from './color/server';
 import exifr from 'exifr';
-import { getOptimizedFileNamesFromUrl } from './storage/server';
-import { getFileNamePartsFromPhotoUrl } from './storage';
+import { getOptimizedFileNamesFromPhotoUrl } from './storage';
 
 const IMAGE_WIDTH_BLUR = 200;
 const IMAGE_WIDTH_RESIZE_SM = 200;
@@ -61,7 +61,7 @@ export const extractImageDataFromBlobPath = async (
 
   const blobId = getIdFromStorageUrl(url);
 
-  const extension = getFileNamePartsFromPhotoUrl(url).fileExtension;
+  const extension = getFileNamePartsFromStorageUrl(url).fileExtension;
 
   let exifData: ExifData | undefined;
   let exifrData: any | undefined;
@@ -280,7 +280,7 @@ export const deletePhotoAndFiles = async (
   photoUrl: string,
 ) =>
   deletePhoto(photoId)
-    .then(() => deleteFile(photoUrl))
-    .then(() => deleteFile(
-      getOptimizedFileNamesFromUrl(photoUrl).urlOptimized,
-    ));
+    .then(() => Promise.all([
+      deleteFile(photoUrl),
+      ...getOptimizedFileNamesFromPhotoUrl(photoUrl).map(deleteFile),
+    ]));

--- a/src/photo/server.ts
+++ b/src/photo/server.ts
@@ -1,5 +1,5 @@
 import {
-  deleteFile,
+  deleteFilesWithPrefix,
   getFileNamePartsFromStorageUrl,
 } from '@/platforms/storage';
 import { convertFormDataToPhotoDbInsert } from '@/photo/form';
@@ -28,7 +28,6 @@ import { PhotoDbInsert } from '.';
 import { convertExifToFormData } from './form/server';
 import { getColorFieldsForPhotoForm } from './color/server';
 import exifr from 'exifr';
-import { getOptimizedUrlsFromPhotoUrl } from './storage';
 
 const IMAGE_WIDTH_BLUR = 200;
 const IMAGE_WIDTH_DEFAULT = 200;
@@ -280,7 +279,7 @@ export const deletePhotoAndFiles = async (
   photoUrl: string,
 ) =>
   deletePhoto(photoId)
-    .then(() => Promise.all([
-      deleteFile(photoUrl),
-      ...getOptimizedUrlsFromPhotoUrl(photoUrl).map(deleteFile),
-    ]));
+    .then(() => {
+      const { fileNameBase } = getFileNamePartsFromStorageUrl(photoUrl);
+      return deleteFilesWithPrefix(fileNameBase);
+    });

--- a/src/photo/server.ts
+++ b/src/photo/server.ts
@@ -1,8 +1,5 @@
 import {
   deleteFile,
-  getExtensionFromStorageUrl,
-  getFileNamePartsFromStorageUrl,
-  getIdFromStorageUrl,
 } from '@/platforms/storage';
 import { convertFormDataToPhotoDbInsert } from '@/photo/form';
 import {
@@ -30,10 +27,13 @@ import { PhotoDbInsert } from '.';
 import { convertExifToFormData } from './form/server';
 import { getColorFieldsForPhotoForm } from './color/server';
 import exifr from 'exifr';
+import { getOptimizedFileNamesFromUrl } from './storage/server';
+import { getExtensionFromStorageUrl, getIdFromStorageUrl } from './storage';
 
 const IMAGE_WIDTH_BLUR = 200;
-const IMAGE_WIDTH_RESIZE_SMALL = 200;
-const IMAGE_WIDTH_RESIZE_LARGE = 1080;
+const IMAGE_WIDTH_RESIZE_SM = 200;
+// const IMAGE_WIDTH_RESIZE_MD = 640;
+const IMAGE_WIDTH_RESIZE_LG = 1080;
 
 export const extractImageDataFromBlobPath = async (
   blobPath: string,
@@ -156,7 +156,7 @@ const generateBase64 = async (
 
 const resizeImage = async (
   image: ArrayBuffer,
-  width = IMAGE_WIDTH_RESIZE_SMALL,
+  width = IMAGE_WIDTH_RESIZE_SM,
 ) => 
   generateBase64(image, sharp => sharp
     .resize(width),
@@ -201,7 +201,7 @@ export const blurImageFromUrl = async (url: string) =>
 
 export const resizeImageToBytes = async (
   image: ArrayBuffer,
-  width = IMAGE_WIDTH_RESIZE_LARGE,
+  width = IMAGE_WIDTH_RESIZE_LG,
 ) => 
   sharp(image)
     .resize(width)
@@ -281,5 +281,5 @@ export const deletePhotoAndFiles = async (
   deletePhoto(photoId)
     .then(() => deleteFile(photoUrl))
     .then(() => deleteFile(
-      getFileNamePartsFromStorageUrl(photoUrl).urlOptimized,
+      getOptimizedFileNamesFromUrl(photoUrl).urlOptimized,
     ));

--- a/src/photo/server.ts
+++ b/src/photo/server.ts
@@ -28,7 +28,7 @@ import { PhotoDbInsert } from '.';
 import { convertExifToFormData } from './form/server';
 import { getColorFieldsForPhotoForm } from './color/server';
 import exifr from 'exifr';
-import { getOptimizedFileNamesFromPhotoUrl } from './storage';
+import { getOptimizedUrlsFromPhotoUrl } from './storage';
 
 const IMAGE_WIDTH_BLUR = 200;
 const IMAGE_WIDTH_DEFAULT = 200;
@@ -282,5 +282,5 @@ export const deletePhotoAndFiles = async (
   deletePhoto(photoId)
     .then(() => Promise.all([
       deleteFile(photoUrl),
-      ...getOptimizedFileNamesFromPhotoUrl(photoUrl).map(deleteFile),
+      ...getOptimizedUrlsFromPhotoUrl(photoUrl).map(deleteFile),
     ]));

--- a/src/photo/storage.ts
+++ b/src/photo/storage.ts
@@ -3,14 +3,16 @@ import {
   deleteFile,
   generateRandomFileNameForPhoto,
   getExtensionFromStorageUrl,
+  getFileNamePartsFromStorageUrl,
+  getPhotoFileName,
   moveFile,
   putFile,
 } from '@/platforms/storage';
-import { removeGpsData } from './server';
+import { removeGpsData, resizeImageToBytes } from './server';
 
 export const convertUploadToPhoto = async ({
   urlOrigin,
-  fileBytes,
+  fileBytes: _fileBytes,
   shouldStripGpsData,
   shouldDeleteOrigin = true,
 } : {
@@ -21,19 +23,42 @@ export const convertUploadToPhoto = async ({
 }) => {
   const fileName = generateRandomFileNameForPhoto();
   const fileExtension = getExtensionFromStorageUrl(urlOrigin);
-  const photoPath = `${fileName}.${fileExtension || 'jpg'}`;
+  const photoPath = getPhotoFileName(fileName, fileExtension);
+  const photoPathOptimized = getPhotoFileName(fileName, fileExtension, true);
+  const fileBytes = _fileBytes
+    ? _fileBytes
+    : await fetch(urlOrigin, { cache: 'no-store' })
+      .then(res => res.arrayBuffer());
+  let promise: Promise<string>;
   if (shouldStripGpsData) {
-    const fileWithoutGps = await removeGpsData(
-      fileBytes ?? await fetch(urlOrigin, { cache: 'no-store' })
-        .then(res => res.arrayBuffer()),
-    );
-    return putFile(fileWithoutGps, photoPath).then(async url => {
+    const fileWithoutGps = await removeGpsData(fileBytes);
+    promise = putFile(fileWithoutGps, photoPath).then(async url => {
       if (url && shouldDeleteOrigin) { await deleteFile(urlOrigin); }
       return url;
     });
   } else {
-    return shouldDeleteOrigin
+    promise = shouldDeleteOrigin
       ? moveFile(urlOrigin, photoPath)
       : copyFile(urlOrigin, photoPath);
   }
+  return promise.then(async url => {
+    // Store optimized photo once original photo is copied/moved
+    await putFile(await resizeImageToBytes(fileBytes), photoPathOptimized);
+    return url;
+  });
+};
+
+export const getOrCreatedOptimizedPhotoUrl = async (url: string) => {
+  const {
+    fileNameOptimized,
+    urlOptimized,
+  } = getFileNamePartsFromStorageUrl(url);
+  const doesUrlExist = await fetch(urlOptimized).then(res => res.ok);
+  if (!doesUrlExist) {
+    console.log('GENERATING JIT OPTIMIZED PHOTO', urlOptimized);
+    const fileBytes = await fetch(url).then(res => res.arrayBuffer());
+    const optimizedFileBytes = await resizeImageToBytes(fileBytes);
+    await putFile(optimizedFileBytes, fileNameOptimized);
+  }
+  return urlOptimized;
 };

--- a/src/photo/storage/client.ts
+++ b/src/photo/storage/client.ts
@@ -1,0 +1,8 @@
+import { uploadFileFromClient } from '@/platforms/storage';
+import { EXTENSION_DEFAULT, PREFIX_UPLOAD } from '.';
+
+export const uploadPhotoFromClient = (
+  file: File | Blob,
+  extension = EXTENSION_DEFAULT,
+) =>
+  uploadFileFromClient(file, PREFIX_UPLOAD, extension);

--- a/src/photo/storage/client.ts
+++ b/src/photo/storage/client.ts
@@ -1,8 +1,0 @@
-import { uploadFileFromClient } from '@/platforms/storage';
-import { EXTENSION_DEFAULT, PREFIX_UPLOAD } from '.';
-
-export const uploadPhotoFromClient = (
-  file: File | Blob,
-  extension = EXTENSION_DEFAULT,
-) =>
-  uploadFileFromClient(file, PREFIX_UPLOAD, extension);

--- a/src/photo/storage/index.ts
+++ b/src/photo/storage/index.ts
@@ -100,9 +100,6 @@ export const getOptimizedPhotoUrl = (
     urlBase,
     fileNameBase,
   } = getFileNamePartsFromStorageUrl(args.imageUrl);
-  if (!compatibilityMode) {
-    console.log('Fetching optimized photo url', args.imageUrl);
-  }
   return compatibilityMode
     ? getNextImageUrlForRequest(args)
     : getOptimizedUrl({ urlBase, fileNameBase, suffix });

--- a/src/photo/storage/index.ts
+++ b/src/photo/storage/index.ts
@@ -65,7 +65,7 @@ export const getOptimizedPhotoFileMeta = (fileNameBase: string) =>
     fileName: getOptimizedFileName({ fileNameBase, suffix }),
   }));
 
-export const getOptimizedFileNamesFromPhotoUrl = (url: string) => {
+export const getOptimizedUrlsFromPhotoUrl = (url: string) => {
   const { urlBase, fileNameBase } = getFileNamePartsFromStorageUrl(url);
   return getOptimizedPhotoFileMeta(fileNameBase).map(({ fileName }) =>
     `${urlBase}/${fileName}`);

--- a/src/photo/storage/index.ts
+++ b/src/photo/storage/index.ts
@@ -139,3 +139,19 @@ export const doAllPhotosHaveOptimizedFiles = async (photos: Photo[]) =>
   Promise.all(photos.map(({ url }) => fetch(getTestOptimizedPhotoUrl(url))))
     .then(urls => urls.every(url => url.ok))
     .catch(() => false);
+
+export const getStorageUrlsForPhoto = async ({ url }: Photo) => {
+  const getSortScoreForUrl = (url: string) => {
+    const { fileNameBase } = getFileNamePartsFromStorageUrl(url);
+    if (fileNameBase.endsWith('-sm')) { return 1; }
+    if (fileNameBase.endsWith('-md')) { return 2; }
+    if (fileNameBase.endsWith('-lg')) { return 3; }
+    return 0;
+  };
+
+  const { fileNameBase } = getFileNamePartsFromStorageUrl(url);
+
+  return getStorageUrlsForPrefix(fileNameBase).then(urls =>
+    urls.sort((a, b) => getSortScoreForUrl(a.url) - getSortScoreForUrl(b.url)),
+  );
+};

--- a/src/photo/storage/index.ts
+++ b/src/photo/storage/index.ts
@@ -1,3 +1,4 @@
+import { NextImageSize } from '@/platforms/next-image';
 import {
   generateFileNameWithId,
   getFileNamePartsFromStorageUrl,
@@ -7,12 +8,38 @@ import {
 
 const PREFIX_PHOTO = 'photo';
 const PREFIX_UPLOAD = 'upload';
-const EXTENSION_DEFAULT = 'jpg';
 
-const OPTIMIZED_SUFFIX_SM = 'sm';
-const OPTIMIZED_SUFFIX_MD = 'md';
-const OPTIMIZED_SUFFIX_LG = 'lg';
-const OPTIMIZED_EXTENSION = 'jpg';
+const EXTENSION_DEFAULT = 'jpg';
+const EXTENSION_OPTIMIZED = 'jpg';
+
+// For the time being, make compatible with `next/image` sizes
+const OPTIMIZED_FILE_SIZES = [{
+  suffix: 'sm',
+  size: 200,
+}, {
+  suffix: 'md',
+  size: 640,
+}, {
+  suffix: 'lg',
+  size: 1080,
+}] as const satisfies {
+  suffix: string
+  size: NextImageSize
+}[];
+
+export type OptimizedSize = (typeof OPTIMIZED_FILE_SIZES)[number]['suffix'];
+
+export const getOptimizedPhotoFileMeta = (fileName: string) =>
+  OPTIMIZED_FILE_SIZES.map(({ suffix, size }) => ({
+    size,
+    fileName: `${fileName}-${suffix}.${EXTENSION_OPTIMIZED}`,
+  }));
+
+export const getOptimizedFileNamesFromPhotoUrl = (url: string) => {
+  const { urlBase, fileName } = getFileNamePartsFromStorageUrl(url);
+  return getOptimizedPhotoFileMeta(fileName).map(({ fileName }) =>
+    `${urlBase}/${fileName}`);
+};
 
 export const isUploadPathnameValid = (pathname?: string) =>
   pathname?.match(new RegExp(`(?:${PREFIX_UPLOAD})\.[a-z]{1,4}`, 'i'));
@@ -25,32 +52,6 @@ export const getStorageUploadUrls = () =>
 
 export const getStoragePhotoUrls = () =>
   getStorageUrlsForPrefix(`${PREFIX_PHOTO}-`);
-
-export const getFileNamePartsFromPhotoUrl = (url: string) => {
-  const parts = getFileNamePartsFromStorageUrl(url);
-  const { fileName } = parts;
-  const fileNameOptimizedSm =
-    `${fileName}-${OPTIMIZED_SUFFIX_SM}.${OPTIMIZED_EXTENSION}`;
-  const fileNameOptimizedMd =
-    `${fileName}-${OPTIMIZED_SUFFIX_MD}.${OPTIMIZED_EXTENSION}`;
-  const fileNameOptimizedLg =
-    `${fileName}-${OPTIMIZED_SUFFIX_LG}.${OPTIMIZED_EXTENSION}`;
-  return {
-    ...parts,
-    fileNameOptimizedSm,
-    fileNameOptimizedMd,
-    fileNameOptimizedLg,
-  };
-};
-
-export const getPhotoFileName = (
-  fileName: string,
-  extension = EXTENSION_DEFAULT,
-  optimize?: 'sm' | 'md' | 'lg',
-) =>
-  Boolean(optimize)
-    ? `${fileName}-${optimize}.${OPTIMIZED_EXTENSION}`
-    : `${fileName}.${extension}`;
 
 export const uploadPhotoFromClient = (
   file: File | Blob,

--- a/src/photo/storage/index.ts
+++ b/src/photo/storage/index.ts
@@ -20,15 +20,19 @@ const EXTENSION_OPTIMIZED = 'jpg';
 const OPTIMIZED_FILE_SIZES = [{
   suffix: 'sm',
   size: 200,
+  quality: 90,
 }, {
   suffix: 'md',
   size: 640,
+  quality: 90,
 }, {
   suffix: 'lg',
   size: 1080,
+  quality: 80,
 }] as const satisfies {
   suffix: string
   size: NextImageSize
+  quality: number
 }[];
 
 type OptimizedSuffix = (typeof OPTIMIZED_FILE_SIZES)[number]['suffix'];
@@ -56,8 +60,8 @@ const getOptimizedUrl =({
   `${urlBase}/${getOptimizedFileName({ fileNameBase, suffix })}`;
 
 export const getOptimizedPhotoFileMeta = (fileNameBase: string) =>
-  OPTIMIZED_FILE_SIZES.map(({ suffix, size }) => ({
-    size,
+  OPTIMIZED_FILE_SIZES.map(({ suffix, ...rest }) => ({
+    ...rest,
     fileName: getOptimizedFileName({ fileNameBase, suffix }),
   }));
 

--- a/src/photo/storage/index.ts
+++ b/src/photo/storage/index.ts
@@ -1,0 +1,27 @@
+export const PREFIX_PHOTO = 'photo';
+export const PREFIX_UPLOAD = 'upload';
+
+export const SUFFIX_OPTIMIZED_SM = 'sm';
+export const SUFFIX_OPTIMIZED_MD = 'md';
+
+export const EXTENSION_DEFAULT = 'jpg';
+export const EXTENSION_OPTIMIZED = 'jpg';
+
+const REGEX_UPLOAD_PATH = new RegExp(
+  `(?:${PREFIX_UPLOAD})\.[a-z]{1,4}`,
+  'i',
+);
+
+const REGEX_UPLOAD_ID = new RegExp(
+  `.${PREFIX_UPLOAD}-([a-z0-9]+)\.[a-z]{1,4}$`,
+  'i',
+);
+
+export const isUploadPathnameValid = (pathname?: string) =>
+  pathname?.match(REGEX_UPLOAD_PATH);
+
+export const getExtensionFromStorageUrl = (url: string) =>
+  url.match(/.([a-z]{1,4})$/i)?.[1];
+
+export const getIdFromStorageUrl = (url: string) =>
+  url.match(REGEX_UPLOAD_ID)?.[1];

--- a/src/photo/storage/index.ts
+++ b/src/photo/storage/index.ts
@@ -1,21 +1,30 @@
-import { getFileNamePartsFromStorageUrl } from '@/platforms/storage';
+import {
+  generateFileNameWithId,
+  getFileNamePartsFromStorageUrl,
+  getStorageUrlsForPrefix,
+  uploadFileFromClient,
+} from '@/platforms/storage';
 
-export const PREFIX_PHOTO = 'photo';
-export const PREFIX_UPLOAD = 'upload';
-export const EXTENSION_DEFAULT = 'jpg';
+const PREFIX_PHOTO = 'photo';
+const PREFIX_UPLOAD = 'upload';
+const EXTENSION_DEFAULT = 'jpg';
 
 const OPTIMIZED_SUFFIX_SM = 'sm';
 const OPTIMIZED_SUFFIX_MD = 'md';
 const OPTIMIZED_SUFFIX_LG = 'lg';
 const OPTIMIZED_EXTENSION = 'jpg';
 
-const REGEX_UPLOAD_PATH = new RegExp(
-  `(?:${PREFIX_UPLOAD})\.[a-z]{1,4}`,
-  'i',
-);
-
 export const isUploadPathnameValid = (pathname?: string) =>
-  pathname?.match(REGEX_UPLOAD_PATH);
+  pathname?.match(new RegExp(`(?:${PREFIX_UPLOAD})\.[a-z]{1,4}`, 'i'));
+
+export const generateRandomFileNameForPhoto = () =>
+  generateFileNameWithId(PREFIX_PHOTO);
+
+export const getStorageUploadUrls = () =>
+  getStorageUrlsForPrefix(`${PREFIX_UPLOAD}-`);
+
+export const getStoragePhotoUrls = () =>
+  getStorageUrlsForPrefix(`${PREFIX_PHOTO}-`);
 
 export const getFileNamePartsFromPhotoUrl = (url: string) => {
   const parts = getFileNamePartsFromStorageUrl(url);
@@ -43,3 +52,8 @@ export const getPhotoFileName = (
     ? `${fileName}-${optimize}.${OPTIMIZED_EXTENSION}`
     : `${fileName}.${extension}`;
 
+export const uploadPhotoFromClient = (
+  file: File | Blob,
+  extension = EXTENSION_DEFAULT,
+) =>
+  uploadFileFromClient(file, PREFIX_UPLOAD, extension);

--- a/src/photo/storage/index.ts
+++ b/src/photo/storage/index.ts
@@ -1,27 +1,45 @@
+import { getFileNamePartsFromStorageUrl } from '@/platforms/storage';
+
 export const PREFIX_PHOTO = 'photo';
 export const PREFIX_UPLOAD = 'upload';
-
-export const SUFFIX_OPTIMIZED_SM = 'sm';
-export const SUFFIX_OPTIMIZED_MD = 'md';
-
 export const EXTENSION_DEFAULT = 'jpg';
-export const EXTENSION_OPTIMIZED = 'jpg';
+
+const OPTIMIZED_SUFFIX_SM = 'sm';
+const OPTIMIZED_SUFFIX_MD = 'md';
+const OPTIMIZED_SUFFIX_LG = 'lg';
+const OPTIMIZED_EXTENSION = 'jpg';
 
 const REGEX_UPLOAD_PATH = new RegExp(
   `(?:${PREFIX_UPLOAD})\.[a-z]{1,4}`,
   'i',
 );
 
-const REGEX_UPLOAD_ID = new RegExp(
-  `.${PREFIX_UPLOAD}-([a-z0-9]+)\.[a-z]{1,4}$`,
-  'i',
-);
-
 export const isUploadPathnameValid = (pathname?: string) =>
   pathname?.match(REGEX_UPLOAD_PATH);
 
-export const getExtensionFromStorageUrl = (url: string) =>
-  url.match(/.([a-z]{1,4})$/i)?.[1];
+export const getFileNamePartsFromPhotoUrl = (url: string) => {
+  const parts = getFileNamePartsFromStorageUrl(url);
+  const { fileName } = parts;
+  const fileNameOptimizedSm =
+    `${fileName}-${OPTIMIZED_SUFFIX_SM}.${OPTIMIZED_EXTENSION}`;
+  const fileNameOptimizedMd =
+    `${fileName}-${OPTIMIZED_SUFFIX_MD}.${OPTIMIZED_EXTENSION}`;
+  const fileNameOptimizedLg =
+    `${fileName}-${OPTIMIZED_SUFFIX_LG}.${OPTIMIZED_EXTENSION}`;
+  return {
+    ...parts,
+    fileNameOptimizedSm,
+    fileNameOptimizedMd,
+    fileNameOptimizedLg,
+  };
+};
 
-export const getIdFromStorageUrl = (url: string) =>
-  url.match(REGEX_UPLOAD_ID)?.[1];
+export const getPhotoFileName = (
+  fileName: string,
+  extension = EXTENSION_DEFAULT,
+  optimize?: 'sm' | 'md' | 'lg',
+) =>
+  Boolean(optimize)
+    ? `${fileName}-${optimize}.${OPTIMIZED_EXTENSION}`
+    : `${fileName}.${extension}`;
+

--- a/src/photo/storage/server.ts
+++ b/src/photo/storage/server.ts
@@ -43,8 +43,9 @@ export const convertUploadToPhoto = async ({
   }
   return promise.then(async url => {
     // Store optimized photos once original photo is copied/moved
-    const optimizedPhotoFileMeta = getOptimizedPhotoFileMeta(fileName);
+    const optimizedPhotoFileMeta = getOptimizedPhotoFileMeta(fileNameBase);
     for (const { size, fileName } of optimizedPhotoFileMeta) {
+      console.log('Storing optimized photo', fileName);
       await putFile(
         await resizeImageToBytes(fileBytes, size),
         fileName,

--- a/src/photo/storage/server.ts
+++ b/src/photo/storage/server.ts
@@ -1,21 +1,12 @@
 import {
   copyFile,
   deleteFile,
-  generateFileNameWithId,
   getFileNamePartsFromStorageUrl,
-  getStorageUrlsForPrefix,
   moveFile,
   putFile,
 } from '@/platforms/storage';
 import { removeGpsData, resizeImageToBytes } from '../server';
-import {
-  PREFIX_PHOTO,
-  PREFIX_UPLOAD,
-  getPhotoFileName,
-} from '.';
-
-export const generateRandomFileNameForPhoto = () =>
-  generateFileNameWithId(PREFIX_PHOTO);
+import { generateRandomFileNameForPhoto, getPhotoFileName } from '.';
 
 export const getOptimizedFileNamesFromUrl = (url: string) => {
   const {
@@ -30,12 +21,6 @@ export const getOptimizedFileNamesFromUrl = (url: string) => {
     urlOptimized,
   };
 };
-
-export const getStorageUploadUrls = () =>
-  getStorageUrlsForPrefix(`${PREFIX_UPLOAD}-`);
-
-export const getStoragePhotoUrls = () =>
-  getStorageUrlsForPrefix(`${PREFIX_PHOTO}-`);
 
 export const convertUploadToPhoto = async ({
   urlOrigin,

--- a/src/photo/storage/server.ts
+++ b/src/photo/storage/server.ts
@@ -1,7 +1,7 @@
 import {
   copyFile,
   deleteFile,
-  generateRandomFileName,
+  generateFileNameWithId,
   getFileNamePartsFromStorageUrl,
   getStorageUrlsForPrefix,
   moveFile,
@@ -11,26 +11,11 @@ import { removeGpsData, resizeImageToBytes } from '../server';
 import {
   PREFIX_PHOTO,
   PREFIX_UPLOAD,
-  EXTENSION_DEFAULT,
-  SUFFIX_OPTIMIZED_SM,
-  SUFFIX_OPTIMIZED_MD,
-  EXTENSION_OPTIMIZED,
-  getExtensionFromStorageUrl,
+  getPhotoFileName,
 } from '.';
 
 export const generateRandomFileNameForPhoto = () =>
-  generateRandomFileName(PREFIX_PHOTO);
-
-export const getPhotoFileName = (
-  fileName: string,
-  extension = EXTENSION_DEFAULT,
-  isOptimized?: 'sm' | 'md',
-) =>
-  isOptimized === 'sm'
-    ? `${fileName}-${SUFFIX_OPTIMIZED_SM}.${EXTENSION_OPTIMIZED}`
-    : isOptimized === 'md'
-      ? `${fileName}-${SUFFIX_OPTIMIZED_MD}.${EXTENSION_OPTIMIZED}`
-      : `${fileName}.${extension}`;
+  generateFileNameWithId(PREFIX_PHOTO);
 
 export const getOptimizedFileNamesFromUrl = (url: string) => {
   const {
@@ -64,7 +49,7 @@ export const convertUploadToPhoto = async ({
   shouldDeleteOrigin?: boolean
 }) => {
   const fileName = generateRandomFileNameForPhoto();
-  const fileExtension = getExtensionFromStorageUrl(urlOrigin);
+  const { fileExtension } = getFileNamePartsFromStorageUrl(urlOrigin);
   const photoPath = getPhotoFileName(fileName, fileExtension);
   const photoPathOptimized = getPhotoFileName(fileName, fileExtension, 'sm');
   const fileBytes = _fileBytes

--- a/src/photo/storage/server.ts
+++ b/src/photo/storage/server.ts
@@ -11,6 +11,18 @@ import {
   getOptimizedPhotoFileMeta,
 } from '.';
 
+export const storeOptimizedPhotos = async (
+  url: string,
+  fileBytes: ArrayBuffer,
+) => {
+  const { fileNameBase } = getFileNamePartsFromStorageUrl(url);
+  const optimizedPhotoFileMeta = getOptimizedPhotoFileMeta(fileNameBase);
+  for (const { fileName, size, quality } of optimizedPhotoFileMeta) {
+    await putFile(await resizeImageToBytes(fileBytes, size, quality), fileName);
+  }
+  return url;
+};
+
 export const convertUploadToPhoto = async ({
   uploadUrl,
   fileBytes: _fileBytes,
@@ -41,15 +53,6 @@ export const convertUploadToPhoto = async ({
       ? moveFile(uploadUrl, fileName)
       : copyFile(uploadUrl, fileName);
   }
-  return promise.then(async url => {
-    // Store optimized photos once original photo is copied/moved
-    const optimizedPhotoFileMeta = getOptimizedPhotoFileMeta(fileNameBase);
-    for (const { size, fileName } of optimizedPhotoFileMeta) {
-      await putFile(
-        await resizeImageToBytes(fileBytes, size),
-        fileName,
-      );
-    }
-    return url;
-  });
+  // Store optimized photos after original photo is copied/moved
+  return promise.then(async url => storeOptimizedPhotos(url, fileBytes));
 };

--- a/src/photo/storage/server.ts
+++ b/src/photo/storage/server.ts
@@ -32,10 +32,11 @@ export const convertUploadToPhoto = async ({
   let promise: Promise<string>;
   if (shouldStripGpsData) {
     const fileWithoutGps = await removeGpsData(fileBytes);
-    promise = putFile(fileWithoutGps, fileName).then(async url => {
-      if (url && shouldDeleteOrigin) { await deleteFile(urlOrigin); }
-      return url;
-    });
+    promise = putFile(fileWithoutGps, fileName)
+      .then(async url => {
+        if (url && shouldDeleteOrigin) { await deleteFile(urlOrigin); }
+        return url;
+      });
   } else {
     promise = shouldDeleteOrigin
       ? moveFile(urlOrigin, fileName)
@@ -45,7 +46,6 @@ export const convertUploadToPhoto = async ({
     // Store optimized photos once original photo is copied/moved
     const optimizedPhotoFileMeta = getOptimizedPhotoFileMeta(fileNameBase);
     for (const { size, fileName } of optimizedPhotoFileMeta) {
-      console.log('Storing optimized photo', fileName);
       await putFile(
         await resizeImageToBytes(fileBytes, size),
         fileName,

--- a/src/photo/storage/server.ts
+++ b/src/photo/storage/server.ts
@@ -12,35 +12,34 @@ import {
 } from '.';
 
 export const convertUploadToPhoto = async ({
-  urlOrigin,
+  uploadUrl,
   fileBytes: _fileBytes,
   shouldStripGpsData,
   shouldDeleteOrigin = true,
 } : {
-  urlOrigin: string
+  uploadUrl: string
   fileBytes?: ArrayBuffer
   shouldStripGpsData?: boolean
   shouldDeleteOrigin?: boolean
 }) => {
   const fileNameBase = generateRandomFileNameForPhoto();
-  const { fileExtension } = getFileNamePartsFromStorageUrl(urlOrigin);
+  const { fileExtension } = getFileNamePartsFromStorageUrl(uploadUrl);
   const fileName = `${fileNameBase}.${fileExtension}`;
   const fileBytes = _fileBytes
     ? _fileBytes
-    : await fetch(urlOrigin, { cache: 'no-store' })
-      .then(res => res.arrayBuffer());
+    : await fetch(uploadUrl).then(res => res.arrayBuffer());
   let promise: Promise<string>;
   if (shouldStripGpsData) {
     const fileWithoutGps = await removeGpsData(fileBytes);
     promise = putFile(fileWithoutGps, fileName)
       .then(async url => {
-        if (url && shouldDeleteOrigin) { await deleteFile(urlOrigin); }
+        if (url && shouldDeleteOrigin) { await deleteFile(uploadUrl); }
         return url;
       });
   } else {
     promise = shouldDeleteOrigin
-      ? moveFile(urlOrigin, fileName)
-      : copyFile(urlOrigin, fileName);
+      ? moveFile(uploadUrl, fileName)
+      : copyFile(uploadUrl, fileName);
   }
   return promise.then(async url => {
     // Store optimized photos once original photo is copied/moved

--- a/src/photo/storage/server.ts
+++ b/src/photo/storage/server.ts
@@ -1,14 +1,56 @@
 import {
   copyFile,
   deleteFile,
-  generateRandomFileNameForPhoto,
-  getExtensionFromStorageUrl,
+  generateRandomFileName,
   getFileNamePartsFromStorageUrl,
-  getPhotoFileName,
+  getStorageUrlsForPrefix,
   moveFile,
   putFile,
 } from '@/platforms/storage';
-import { removeGpsData, resizeImageToBytes } from './server';
+import { removeGpsData, resizeImageToBytes } from '../server';
+import {
+  PREFIX_PHOTO,
+  PREFIX_UPLOAD,
+  EXTENSION_DEFAULT,
+  SUFFIX_OPTIMIZED_SM,
+  SUFFIX_OPTIMIZED_MD,
+  EXTENSION_OPTIMIZED,
+  getExtensionFromStorageUrl,
+} from '.';
+
+export const generateRandomFileNameForPhoto = () =>
+  generateRandomFileName(PREFIX_PHOTO);
+
+export const getPhotoFileName = (
+  fileName: string,
+  extension = EXTENSION_DEFAULT,
+  isOptimized?: 'sm' | 'md',
+) =>
+  isOptimized === 'sm'
+    ? `${fileName}-${SUFFIX_OPTIMIZED_SM}.${EXTENSION_OPTIMIZED}`
+    : isOptimized === 'md'
+      ? `${fileName}-${SUFFIX_OPTIMIZED_MD}.${EXTENSION_OPTIMIZED}`
+      : `${fileName}.${extension}`;
+
+export const getOptimizedFileNamesFromUrl = (url: string) => {
+  const {
+    urlBase,
+    fileNameBase,
+    fileExtension,
+  } = getFileNamePartsFromStorageUrl(url);
+  const fileNameOptimized = getPhotoFileName(fileNameBase, fileExtension, 'sm');
+  const urlOptimized = `${urlBase}/${fileNameOptimized}`;
+  return {
+    fileNameOptimized,
+    urlOptimized,
+  };
+};
+
+export const getStorageUploadUrls = () =>
+  getStorageUrlsForPrefix(`${PREFIX_UPLOAD}-`);
+
+export const getStoragePhotoUrls = () =>
+  getStorageUrlsForPrefix(`${PREFIX_PHOTO}-`);
 
 export const convertUploadToPhoto = async ({
   urlOrigin,
@@ -24,7 +66,7 @@ export const convertUploadToPhoto = async ({
   const fileName = generateRandomFileNameForPhoto();
   const fileExtension = getExtensionFromStorageUrl(urlOrigin);
   const photoPath = getPhotoFileName(fileName, fileExtension);
-  const photoPathOptimized = getPhotoFileName(fileName, fileExtension, true);
+  const photoPathOptimized = getPhotoFileName(fileName, fileExtension, 'sm');
   const fileBytes = _fileBytes
     ? _fileBytes
     : await fetch(urlOrigin, { cache: 'no-store' })
@@ -43,7 +85,10 @@ export const convertUploadToPhoto = async ({
   }
   return promise.then(async url => {
     // Store optimized photo once original photo is copied/moved
-    await putFile(await resizeImageToBytes(fileBytes), photoPathOptimized);
+    await putFile(
+      await resizeImageToBytes(fileBytes, 640),
+      photoPathOptimized,
+    );
     return url;
   });
 };
@@ -52,12 +97,12 @@ export const getOrCreatedOptimizedPhotoUrl = async (url: string) => {
   const {
     fileNameOptimized,
     urlOptimized,
-  } = getFileNamePartsFromStorageUrl(url);
+  } = getOptimizedFileNamesFromUrl(url);
   const doesUrlExist = await fetch(urlOptimized).then(res => res.ok);
   if (!doesUrlExist) {
     console.log('GENERATING JIT OPTIMIZED PHOTO', urlOptimized);
     const fileBytes = await fetch(url).then(res => res.arrayBuffer());
-    const optimizedFileBytes = await resizeImageToBytes(fileBytes);
+    const optimizedFileBytes = await resizeImageToBytes(fileBytes, 640);
     await putFile(optimizedFileBytes, fileNameOptimized);
   }
   return urlOptimized;

--- a/src/photo/update/server.ts
+++ b/src/photo/update/server.ts
@@ -1,0 +1,10 @@
+import { Photo, PhotoDbInsert } from '..';
+import { doesPhotoUrlHaveOptimizedFiles } from '../storage';
+
+// Used to anonymize storage/create optimized files if necessary
+// by re-running convertUploadToPhoto (image upload transfer logic)
+export const shouldBackfillPhotoStorage = async (
+  photo: Photo | PhotoDbInsert,
+) =>
+  photo.url.includes(photo.id) ||
+  !await doesPhotoUrlHaveOptimizedFiles(photo.url);

--- a/src/platforms/next-image.ts
+++ b/src/platforms/next-image.ts
@@ -39,15 +39,3 @@ export const getNextImageUrlForRequest = ({
 
   return url.toString();
 };
-
-// Generate small, low-bandwidth images for quick manipulations such as
-// generating blur data or image thumbnails for AI text generation
-export const getNextImageUrlForManipulation = (
-  imageUrl: string,
-  addBypassSecret: boolean,
-) =>
-  getNextImageUrlForRequest({
-    imageUrl,
-    size: 640,
-    addBypassSecret,
-  });

--- a/src/platforms/safe-photo-image-response.ts
+++ b/src/platforms/safe-photo-image-response.ts
@@ -1,14 +1,14 @@
 import { Photo } from '@/photo';
 import { ImageResponse } from 'next/og';
 import { JSX } from 'react';
-import { getNextImageUrlForRequest } from './next-image';
 import { IS_PREVIEW } from '@/app/config';
+import { getOptimizedPhotoUrl } from '@/photo/storage';
 
 const isNextImageReadyBasedOnPhotos = async (
   photos: Photo[],
 ): Promise<boolean> =>
   photos.length > 0 &&
-  fetch(getNextImageUrlForRequest({
+  fetch(getOptimizedPhotoUrl({
     imageUrl: photos[0].url,
     size: 640,
     addBypassSecret: IS_PREVIEW,

--- a/src/platforms/storage/aws-s3.ts
+++ b/src/platforms/storage/aws-s3.ts
@@ -6,7 +6,7 @@ import {
   PutObjectCommand,
 } from '@aws-sdk/client-s3';
 import { StorageListResponse, generateStorageId } from '.';
-import { formatBytesToMB } from '@/utility/number';
+import { formatBytes } from '@/utility/number';
 
 const AWS_S3_BUCKET = process.env.NEXT_PUBLIC_AWS_S3_BUCKET ?? '';
 const AWS_S3_REGION = process.env.NEXT_PUBLIC_AWS_S3_REGION ?? '';
@@ -75,7 +75,7 @@ export const awsS3List = async (
       url: urlForKey(Key),
       fileName: Key ?? '',
       uploadedAt: LastModified,
-      size: Size ? formatBytesToMB(Size) : undefined,
+      size: Size ? formatBytes(Size) : undefined,
     })) ?? []);
 
 export const awsS3Delete = async (Key: string) => {

--- a/src/platforms/storage/cache.ts
+++ b/src/platforms/storage/cache.ts
@@ -2,7 +2,7 @@ import { unstable_noStore } from 'next/cache';
 import {
   getStoragePhotoUrls,
   getStorageUploadUrls,
-} from '@/photo/storage/server';
+} from '@/photo/storage';
 
 export const getStorageUploadUrlsNoStore: typeof getStorageUploadUrls =
   (...args) => {

--- a/src/platforms/storage/cache.ts
+++ b/src/platforms/storage/cache.ts
@@ -1,5 +1,8 @@
 import { unstable_noStore } from 'next/cache';
-import { getStoragePhotoUrls, getStorageUploadUrls } from '@/platforms/storage';
+import {
+  getStoragePhotoUrls,
+  getStorageUploadUrls,
+} from '@/photo/storage/server';
 
 export const getStorageUploadUrlsNoStore: typeof getStorageUploadUrls =
   (...args) => {

--- a/src/platforms/storage/cloudflare-r2.ts
+++ b/src/platforms/storage/cloudflare-r2.ts
@@ -7,7 +7,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { StorageListResponse, generateStorageId } from '.';
 import { removeUrlProtocol } from '@/utility/url';
-import { formatBytesToMB } from '@/utility/number';
+import { formatBytes } from '@/utility/number';
 
 const CLOUDFLARE_R2_BUCKET =
   process.env.NEXT_PUBLIC_CLOUDFLARE_R2_BUCKET ?? '';
@@ -95,7 +95,7 @@ export const cloudflareR2List = async (
       url: urlForKey(Key),
       fileName: Key ?? '',
       uploadedAt: LastModified,
-      size: Size ? formatBytesToMB(Size) : undefined,
+      size: Size ? formatBytes(Size) : undefined,
     })) ?? []);
 
 export const cloudflareR2Delete = async (Key: string) => {

--- a/src/platforms/storage/index.ts
+++ b/src/platforms/storage/index.ts
@@ -42,8 +42,11 @@ import { PATH_API_PRESIGNED_URL } from '@/app/path';
 
 export const generateStorageId = () => generateNanoid(16);
 
-export const generateRandomFileName = (fileNamePrefix: string) =>
+export const generateFileNameWithId = (fileNamePrefix: string) =>
   `${fileNamePrefix}-${generateStorageId()}`;
+
+export const getIdFromStorageUrl = (url: string) =>
+  url.match(/-([a-z0-9]+)\.[a-z]{1,4}$/i)?.[1];
 
 export type StorageListItem = {
   url: string

--- a/src/platforms/storage/index.ts
+++ b/src/platforms/storage/index.ts
@@ -200,6 +200,11 @@ export const deleteFile = (url: string) => {
   }
 };
 
+export const deleteFilesWithPrefix = async (prefix: string) => {
+  const urls = await getStorageUrlsForPrefix(prefix);
+  return Promise.all(urls.map(({ url }) => deleteFile(url)));
+};
+
 export const moveFile = async (
   originUrl: string,
   destinationFileName: string,

--- a/src/platforms/storage/minio.ts
+++ b/src/platforms/storage/minio.ts
@@ -65,7 +65,8 @@ export const minioCopy = async (
     : fileNameDestination;
   return minioClient().send(new CopyObjectCommand({
     Bucket: MINIO_BUCKET,
-    CopySource: fileNameSource,
+    // Bucket behavior seems to differ from R2 + S3
+    CopySource: `${MINIO_BUCKET}/${fileNameSource}`,
     Key,
   }))
     .then(() => urlForKey(Key));

--- a/src/platforms/storage/minio.ts
+++ b/src/platforms/storage/minio.ts
@@ -6,7 +6,7 @@ import {
   DeleteObjectCommand,
 } from '@aws-sdk/client-s3';
 import { StorageListResponse, generateStorageId } from '.';
-import { formatBytesToMB } from '@/utility/number';
+import { formatBytes } from '@/utility/number';
 
 const MINIO_BUCKET = process.env.NEXT_PUBLIC_MINIO_BUCKET ?? '';
 const MINIO_DOMAIN = process.env.NEXT_PUBLIC_MINIO_DOMAIN ?? '';
@@ -82,7 +82,7 @@ export const minioList = async (
       url: urlForKey(Key),
       fileName: Key ?? '',
       uploadedAt: LastModified,
-      size: Size ? formatBytesToMB(Size) : undefined,
+      size: Size ? formatBytes(Size) : undefined,
     })) ?? []);
 
 export const minioDelete = async (Key: string): Promise<void> => {

--- a/src/platforms/storage/vercel-blob.ts
+++ b/src/platforms/storage/vercel-blob.ts
@@ -1,7 +1,7 @@
 import { PATH_API_VERCEL_BLOB_UPLOAD } from '@/app/path';
 import { copy, del, list, put } from '@vercel/blob';
 import { upload } from '@vercel/blob/client';
-import { getFilePathFromStorageUrl, StorageListResponse } from '.';
+import { getFileNamePartsFromStorageUrl, StorageListResponse } from '.';
 import { formatBytesToMB } from '@/utility/number';
 
 const VERCEL_BLOB_STORE_ID = process.env.BLOB_READ_WRITE_TOKEN?.match(
@@ -55,7 +55,7 @@ export const vercelBlobList = (
 ): Promise<StorageListResponse> => list({ prefix })
   .then(({ blobs }) => blobs.map(({ url, uploadedAt, size }) => ({
     url,
-    fileName: getFilePathFromStorageUrl(url),
+    fileName: getFileNamePartsFromStorageUrl(url).fileName,
     uploadedAt,
     size: formatBytesToMB(size),
   })));

--- a/src/platforms/storage/vercel-blob.ts
+++ b/src/platforms/storage/vercel-blob.ts
@@ -2,7 +2,7 @@ import { PATH_API_VERCEL_BLOB_UPLOAD } from '@/app/path';
 import { copy, del, list, put } from '@vercel/blob';
 import { upload } from '@vercel/blob/client';
 import { getFileNamePartsFromStorageUrl, StorageListResponse } from '.';
-import { formatBytesToMB } from '@/utility/number';
+import { formatBytes } from '@/utility/number';
 
 const VERCEL_BLOB_STORE_ID = process.env.BLOB_READ_WRITE_TOKEN?.match(
   /^vercel_blob_rw_([a-z0-9]+)_[a-z0-9]+$/i,
@@ -57,5 +57,5 @@ export const vercelBlobList = (
     url,
     fileName: getFileNamePartsFromStorageUrl(url).fileName,
     uploadedAt,
-    size: formatBytesToMB(size),
+    size: formatBytes(size),
   })));

--- a/src/utility/number.ts
+++ b/src/utility/number.ts
@@ -88,12 +88,13 @@ export const formatNumberToFraction = (number: number) => {
   }
 };
 
-export const formatBytesToMB = (
+export const formatBytes = (
   bytes: number,
   byteSize = 1000,
-  precision = 1,
 ) =>
-  `${(bytes / byteSize / byteSize).toFixed(precision)}MB`;
+  bytes < byteSize * byteSize
+    ? `${Math.round(bytes / byteSize)}KB`
+    : `${(bytes / byteSize / byteSize).toFixed(1)}MB`;
 
 export const convertNumberToRomanNumeral = (number: number) => {
   const romanNumerals = [


### PR DESCRIPTION
- Begin creating optimized assets for all new uploads:
  - `photo-{storageId}-sm.jpg`
  - `photo-{storageId}-md.jpg`
  - `photo-{storageId}-lg.jpg`
- Serve optimized (instead of `next/image`) urls when they exist for operations like og image generation and image manipulation
- Separate (+ simplify) storage manipulation from photo organizational logic