### PR TITLE
chore: fix tsconfig json syntax

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"],
-    },
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION

<img width="1471" height="939" alt="截屏2025-10-22 00 04 40" src="https://github.com/user-attachments/assets/40a44563-effc-4d37-97da-d83339166024" />
Remove trailing commas from tsconfig.json so the file becomes valid JSON.
Prevents Tencent Cloud EdgeOne Pages from throwing SyntaxError: expected double-quoted property name in JSON during build, allowing successful deployments.
EdgeOne Pages invokes a build that reads [tsconfig.json] with a strict JSON parser (native JSON.parse). The original file contained JSONC-style trailing commas which cause parsing to fail on EdgeOne's builder and abort the deployment. Converting the file to strict JSON resolves the issue.