### PR TITLE
fix(app): add normalize func for redis url

### DIFF
--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -165,11 +165,30 @@ export const POSTGRES_SSL_ENABLED =
   process.env.DISABLE_POSTGRES_SSL === '1' ? false : true;
 
 // STORAGE: REDIS
-export const REDIS_URL = (
-  process.env.KV_URL ||
+
+/**
+ * Normalizes a Redis URL for use with @upstash/redis.
+ *
+ * The SDK requires an HTTPS REST URL, but some providers (e.g. Vercel KV)
+ * supply a native `rediss://` protocol URL. This converts `rediss://` to
+ * `https://` by extracting the hostname, so either format works.
+ */
+const normalizeRedisRestUrl = (url: string | undefined): string | undefined => {
+  if (!url || !url.startsWith('rediss://')) return url;
+  try {
+    return `https://${new URL(url).hostname}`;
+  } catch {
+    return url;
+  }
+};
+
+// Priority: REST API first (native https://, preferred by @upstash/redis),
+// then rediss:// KV_URL (auto-normalized), then custom fallbacks.
+export const REDIS_URL = normalizeRedisRestUrl(
   process.env.KV_REST_API_URL ||
   process.env.EXIF_KV_REST_API_URL ||
-  process.env.UPSTASH_REDIS_REST_URL
+  process.env.KV_URL ||
+  process.env.UPSTASH_REDIS_REST_URL,
 );
 export const REDIS_TOKEN = (
   process.env.KV_TOKEN ||


### PR DESCRIPTION
## Summary

Fixes a build crash when `@upstash/redis` receives a `rediss://` protocol URL instead of `https://`.

## Problem

The `@upstash/redis` SDK requires an HTTPS REST URL, but Vercel KV sets `KV_URL` to a native Redis protocol URL (`rediss://default:token@host:6379`). Since `KV_URL` was checked before `KV_REST_API_URL` in the fallback chain, the SDK received the wrong URL format and threw `UrlError` at build time.

## Changes

- **`src/app/config.ts`** — Added `normalizeRedisRestUrl()` helper that extracts the hostname from `rediss://` URLs and converts them to `https://`. Reordered the env var priority so `KV_REST_API_URL` (native `https://`) is preferred over `KV_URL` (`rediss://`).

## Testing

- `KV_URL=rediss://default:token@instance.upstash.io:6379 pnpm build` — succeeds (previously crashed with `UrlError`)
- `pnpm lint` — 0 errors, 0 warnings
- `tsc --noEmit` — compiles cleanly