### PR TITLE
fix: allow captions even when title isn't filled

### DIFF
--- a/src/photo/form/index.ts
+++ b/src/photo/form/index.ts
@@ -94,8 +94,6 @@ const FORM_METADATA = (
     label: 'caption',
     capitalize: true,
     validateStringMaxLength: STRING_MAX_LENGTH_LONG,
-    shouldHide: ({ title, caption }) =>
-      !aiTextGeneration && (!title && !caption),
   },
   tags: {
     section: 'text',


### PR DESCRIPTION
very small fix, checked the UI with various view points and everything lgtm

sidenote: wanted to check if you're open to removing `className="uppercase"` from captions -- i'd prefer to have control over this but understand if this was an intentional stylistic choice!