### PR TITLE
Fix mobile fast-scroll crash and close accessibility gaps

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,10 +2,15 @@ import { defineConfig, globalIgnores } from 'eslint/config';
 import nextVitals from 'eslint-config-next/core-web-vitals';
 import nextTs from 'eslint-config-next/typescript';
 import stylistic from '@stylistic/eslint-plugin';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
 
 export default defineConfig([
   ...nextVitals,
   ...nextTs,
+  // eslint-config-next already registers the jsx-a11y plugin itself, so
+  // only apply its recommended rules here rather than the full flat config
+  // (which would redefine the plugin and error)
+  { rules: jsxA11y.flatConfigs.recommended.rules },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "cross-fetch": "^4.1.0",
     "eslint": "9.39.2",
     "eslint-config-next": "16.3.1",
+    "eslint-plugin-jsx-a11y": "6.10.2",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
     "postcss": "8.5.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       eslint-config-next:
         specifier: 16.3.1
         version: 16.3.1(@typescript-eslint/parser@8.46.4(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      eslint-plugin-jsx-a11y:
+        specifier: 6.10.2
+        version: 6.10.2(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@26.2.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@26.2.0)(typescript@6.0.3))
@@ -6583,7 +6586,7 @@ snapshots:
 
   browserslist@4.28.0:
     dependencies:
-      baseline-browser-mapping: 2.10.43
+      baseline-browser-mapping: 2.11.14
       caniuse-lite: 1.0.30001754
       electron-to-chromium: 1.5.253
       node-releases: 2.0.27

--- a/src/admin/AdminUploadsTableRow.tsx
+++ b/src/admin/AdminUploadsTableRow.tsx
@@ -90,7 +90,7 @@ export default function AdminUploadsTableRow({
         <ImageMedium
           title={fileId}
           src={url}
-          alt={url}
+          alt={fileId}
           aspectRatio={3.0 / 2.0}
           className={clsx(
             'bg-dim',

--- a/src/admin/edit-titles/EditTitlesProvider.tsx
+++ b/src/admin/edit-titles/EditTitlesProvider.tsx
@@ -133,7 +133,6 @@ export default function EditTitlesProvider({
 
   useEffect(() => {
     if (!isEditingTitles) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setPhotoEdits({});
       setIsPerformingUpdate(false);
     }

--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -39,7 +39,7 @@ export default function Footer() {
           type={!shouldAnimate ? 'none' : 'bottom'}
           distanceOffset={10}
           items={showFooter
-            ? [<div
+            ? [<footer
               key="footer"
               className={clsx(
                 'flex items-center gap-1',
@@ -75,7 +75,7 @@ export default function Footer() {
               <div className="flex items-center h-10 shrink-0">
                 <ThemeSwitcher />
               </div>
-            </div>]
+            </footer>]
             : []}
         />}
     />

--- a/src/components/AnchorSections.tsx
+++ b/src/components/AnchorSections.tsx
@@ -97,7 +97,6 @@ function AnchorSection({
 
   return (
     <div ref={ref} {...{ id, className }}>
-      <a href={`#${id}`} />
       {children}
     </div>
   );

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -32,7 +32,6 @@ export default function Checkbox({
           ? 'cursor-not-allowed'
           : 'group-has-active:opacity-70',
       )}
-      onClick={() => ref?.current?.click()}
     >
       {accessory
         ? accessory

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -23,6 +23,7 @@ export default function CopyButton({
   return (
     <LoaderButton
       {...props}
+      aria-label={label}
       icon={<BiCopy size={iconSize} />}
       className={clsx(
         subtle && 'text-gray-300 dark:text-gray-700',

--- a/src/components/DownloadButton.tsx
+++ b/src/components/DownloadButton.tsx
@@ -20,6 +20,7 @@ export default function DownloadButton({
   return (
     <LoaderButton
       tooltip={appText.tooltip.download}
+      aria-label={appText.tooltip.download}
       className={clsx(
         className,
         'text-medium',

--- a/src/components/ErrorNote.tsx
+++ b/src/components/ErrorNote.tsx
@@ -11,6 +11,7 @@ export default function ErrorNote({
 }) {
   return (
     <Note
+      role="alert"
       color="red"
       padding="tight"
       className={className}

--- a/src/components/FieldsetWithStatus.tsx
+++ b/src/components/FieldsetWithStatus.tsx
@@ -98,6 +98,8 @@ export default function FieldsetWithStatus({
 
   const readOnly = readOnlyProp || pending || loading;
 
+  const errorId = error ? `${id}-error` : undefined;
+
   const inputProps: InputHTMLAttributes<HTMLInputElement> = {
     id,
     name: id,
@@ -117,6 +119,10 @@ export default function FieldsetWithStatus({
     disabled: type === 'checkbox' && (
       readOnly || pending || loading
     ),
+    required,
+    'aria-required': required,
+    'aria-invalid': Boolean(error),
+    'aria-describedby': errorId,
     className: clsx(
       (
         type === 'text' ||
@@ -184,7 +190,7 @@ export default function FieldsetWithStatus({
                 *
               </span>}
             {error &&
-              <span className="text-error">
+              <span id={errorId} className="text-error">
                 {error}
               </span>}
             {required &&
@@ -240,6 +246,10 @@ export default function FieldsetWithStatus({
                   readOnly={readOnly}
                   spellCheck={spellCheck}
                   autoCapitalize={!capitalize ? 'off' : undefined}
+                  required={required}
+                  aria-required={required}
+                  aria-invalid={Boolean(error)}
+                  aria-describedby={errorId}
                   className={clsx(
                     'w-full h-24 resize-none',
                     Boolean(error) && 'error',

--- a/src/components/SelectMenuOption.tsx
+++ b/src/components/SelectMenuOption.tsx
@@ -36,6 +36,13 @@ export default function SelectMenuOption<T = string>({
   }, [isHighlighted]);
 
   return (
+  // Keyboard navigation (arrow keys + Enter) is handled by the parent
+  // SelectMenu's combobox keydown listener, which keeps focus on the
+  // combobox trigger rather than these options (standard ARIA combobox
+  // pattern) — this onClick is for pointer users only
+    /* eslint-disable-next-line
+      jsx-a11y/click-events-have-key-events,
+      jsx-a11y/interactive-supports-focus */
     <div
       ref={ref}
       onClick={onClick}

--- a/src/components/SelectTileOverlay.tsx
+++ b/src/components/SelectTileOverlay.tsx
@@ -21,8 +21,13 @@ export default function SelectTileOverlay({
       isPerformingSelectEdit && 'pointer-events-none',
     )}>
       {/* Admin Select Border */}
-      <div
-        className="w-full h-full"
+      <button
+        type="button"
+        aria-label={isSelected ? 'Deselect photo' : 'Select photo'}
+        className={clsx(
+          'w-full h-full',
+          'border-none shadow-none p-0 rounded-none bg-transparent',
+        )}
         onClick={onSelectChange}
       >
         <div
@@ -34,7 +39,7 @@ export default function SelectTileOverlay({
             isSelected && 'border-4',
           )}
         />
-      </div>
+      </button>
       {/* Admin Select Action */}
       <div className="absolute top-0 right-0 p-2">
         {isPerformingSelectEdit

--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -355,9 +355,9 @@ export default function TagInput({
         {selectedOptions
           .filter(Boolean)
           .map(option =>
-            <span
+            <button
               key={option}
-              role="button"
+              type="button"
               aria-label={`Remove tag "${option}"`}
               className={clsx(
                 'inline-flex items-center gap-2 min-w-0',
@@ -368,12 +368,13 @@ export default function TagInput({
                 'bg-gray-200/60 dark:bg-gray-800',
                 'active:bg-gray-200 dark:active:bg-gray-900',
                 'rounded-sm',
+                'border-none shadow-none',
               )}
               onClick={() => removeOption(option)}
             >
               {defaultIconSelected}
               {renderTag(labelForValueOverride?.(option) || option)}
-            </span>)}
+            </button>)}
         <input
           id={id}
           ref={inputRef}
@@ -432,6 +433,11 @@ export default function TagInput({
                 annotation,
                 annotationAria,
               }, index) =>
+                // Enter/Arrow key handling for focused options is done by
+                // the container-level keydown listener above (bubbles up
+                // from whichever option is focused) rather than inline here
+                /* eslint-disable-next-line
+                  jsx-a11y/click-events-have-key-events */
                 <div
                   key={value}
                   role="option"

--- a/src/components/primitives/LoaderButton.tsx
+++ b/src/components/primitives/LoaderButton.tsx
@@ -72,7 +72,14 @@ export default function LoaderButton({
         styleAs === 'link-without-hover' && 'hover:text-main',
         'inline-flex items-center gap-1.5 self-start whitespace-nowrap',
         primary && 'primary',
-        hideFocusOutline && 'focus:outline-hidden',
+        // Hide the default (mouse-click) focus ring, but keep a visible
+        // one for keyboard navigation
+        hideFocusOutline && [
+          'focus:outline-hidden',
+          'focus-visible:outline-2',
+          'focus-visible:outline-blue-600',
+          'focus-visible:outline-offset-2',
+        ],
         className,
       )}
       disabled={isLoading || disabled}

--- a/src/components/primitives/SimpleCheckbox.tsx
+++ b/src/components/primitives/SimpleCheckbox.tsx
@@ -21,11 +21,6 @@ export default function SimpleCheckbox(props: {
         'cursor-pointer active:opacity-50',
         className,
       )}
-      onClick={() => {
-        if (inputRef.current) {
-          inputRef.current.checked = !inputRef.current.checked;
-        }
-      }}
     >
       <input
         {...rest}

--- a/src/components/primitives/TooltipPrimitive.tsx
+++ b/src/components/primitives/TooltipPrimitive.tsx
@@ -98,6 +98,12 @@ export default function TooltipPrimitive({
             >
               {children}
             </button>
+            // This span wraps `children`, always a real interactive element
+            // (button/link) — onClick here only clears focus as a side
+            // effect and doesn't need its own keyboard handling
+            /* eslint-disable-next-line
+              jsx-a11y/no-static-element-interactions,
+              jsx-a11y/click-events-have-key-events */
             : <span
               className={classNameTrigger}
               onClick={clearGlobalFocus}

--- a/src/components/switcher/SwitcherItem.tsx
+++ b/src/components/switcher/SwitcherItem.tsx
@@ -38,6 +38,10 @@ export default function SwitcherItem({
   tooltip?: ComponentProps<typeof Tooltip>
   width?: 'narrow' | 'normal'
 }) {
+  const ariaLabel = typeof tooltip?.content === 'string'
+    ? tooltip.content
+    : undefined;
+
   const widthClass = width === 'narrow' ? WIDTH_CLASS_NARROW : WIDTH_CLASS;
   const className = clsx(
     'flex items-center justify-center',
@@ -73,10 +77,20 @@ export default function SwitcherItem({
       prefetch,
       icon: renderIcon(),
       loader: <Spinner />,
-    }} />
-    : <div {...{ title, onClick, className }}>
-      {renderIcon()}
-    </div>;
+    }}
+    aria-label={ariaLabel ?? title}
+    />
+    : onClick
+      ? <button
+        type="button"
+        {...{ title, onClick, className }}
+        aria-label={ariaLabel ?? title}
+      >
+        {renderIcon()}
+      </button>
+      : <div {...{ title, className }}>
+        {renderIcon()}
+      </div>;
 
   return (
     tooltip

--- a/src/photo/InfinitePhotoScroll.tsx
+++ b/src/photo/InfinitePhotoScroll.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import useSwrInfinite from 'swr/infinite';
-import { ReactNode, useCallback, useMemo, useRef } from 'react';
+import {
+  ReactNode,
+  useCallback,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
 import AppGrid from '@/components/AppGrid';
 import Spinner from '@/components/Spinner';
 import { getPhotosCachedAction, getPhotosAction } from '@/photo/actions';
@@ -17,6 +23,12 @@ import { useAppText } from '@/i18n/state/client';
 const SIZE_KEY_SEPARATOR = '__';
 const getSizeFromKey = (key: string) =>
   parseInt(key.split(SIZE_KEY_SEPARATOR)[1]);
+
+// Used to defer client-only rendering until after mount without a
+// setState-in-effect cascading render (see useSyncExternalStore usage below)
+const subscribeNoop = () => () => {};
+const getSnapshotClient = () => true;
+const getSnapshotServer = () => false;
 
 export type RevalidatePhoto = (
   photoId: string,
@@ -67,7 +79,7 @@ export default function InfinitePhotoScroll({
   }) => ReactNode
 } & PhotoSetCategory) {
   const { isUserSignedIn } = useAppState();
-  
+
   const { utility } = useAppText();
 
   const keyGenerator = useCallback(
@@ -83,7 +95,7 @@ export default function InfinitePhotoScroll({
   ) =>
     (useCachedPhotos ? getPhotosCachedAction : getPhotosAction)({
       offset: initialOffset + getSizeFromKey(keyWithSize) * itemsPerPage,
-      sortBy, 
+      sortBy,
       sortWithPriority,
       excludeFromFeeds,
       limit: itemsPerPage,
@@ -130,8 +142,19 @@ export default function InfinitePhotoScroll({
     );
 
   const buttonContainerRef = useRef<HTMLDivElement>(null);
-  
+
   const isLoadingOrValidating = isLoading || isValidating;
+
+  // SWR's loading state can differ between the server-rendered pass and the
+  // client's first hydration pass, causing a hydration mismatch on the
+  // "load more" button below. useSyncExternalStore lets the server and
+  // client intentionally diverge here without triggering that mismatch.
+  const hasMounted = useSyncExternalStore(
+    subscribeNoop,
+    getSnapshotClient,
+    getSnapshotServer,
+  );
+  const isLoadingOrValidatingForDisplay = hasMounted && isLoadingOrValidating;
 
   const isFinished = useMemo(() =>
     data && data[data.length - 1]?.length < itemsPerPage
@@ -161,15 +184,15 @@ export default function InfinitePhotoScroll({
       <button
         type="button"
         onClick={() => error ? mutate() : advance()}
-        disabled={isLoading || isValidating}
+        disabled={isLoadingOrValidatingForDisplay}
         className={clsx(
           'w-full flex justify-center',
-          isLoadingOrValidating && 'subtle',
+          isLoadingOrValidatingForDisplay && 'subtle',
         )}
       >
         {error
           ? utility.tryAgain
-          : isLoadingOrValidating
+          : isLoadingOrValidatingForDisplay
             ? <Spinner size={20} />
             : utility.loadMore}
       </button>

--- a/src/photo/PhotoGrid.tsx
+++ b/src/photo/PhotoGrid.tsx
@@ -72,6 +72,9 @@ export default function PhotoGrid({
       style={{
         ...(MASONRY_GRID_ENABLED) ? {
           aspectRatio: photo.aspectRatio,
+          // Skip render/paint work for tiles scrolled off-screen — height
+          // stays derived from aspectRatio, so this doesn't affect layout
+          contentVisibility: 'auto',
         } : (GRID_ASPECT_RATIO !== 0) ? {
           aspectRatio: GRID_ASPECT_RATIO,
         } : {},

--- a/src/photo/form/FieldsetPhotoChooser.tsx
+++ b/src/photo/form/FieldsetPhotoChooser.tsx
@@ -83,12 +83,15 @@ export default function FieldsetPhotoChooser({
   }, [isOpen, reset]);
 
   const renderPhotoButton = (photo: Photo) =>
-    <span
+    <button
+      type="button"
       key={photo.id}
+      aria-label={altTextForPhoto(photo)}
       className={clsx(
         'flex w-full aspect-square object-cover',
         'overflow-hidden select-none active:opacity-75',
         'cursor-pointer',
+        'border-none shadow-none p-0 rounded-none bg-transparent',
       )}
       onClick={() => {
         setPhoto(photo);
@@ -97,7 +100,7 @@ export default function FieldsetPhotoChooser({
       }}
     >
       {renderPhoto(photo)}
-    </span>;
+    </button>;
 
   const photosToShow = showQuery && query
     ? photosQuery

--- a/src/photo/form/PhotoForm.tsx
+++ b/src/photo/form/PhotoForm.tsx
@@ -400,7 +400,7 @@ export default function PhotoForm({
   const thumbnail = (includeRef?: boolean, className?: string) =>
     <ImageWithFallback
       ref={includeRef ? ref : undefined}
-      alt="Upload"
+      alt={formData.title || 'Photo thumbnail'}
       src={url}
       className={clsx(
         'border rounded-md overflow-hidden',

--- a/src/share/ShareButton.tsx
+++ b/src/share/ShareButton.tsx
@@ -7,6 +7,7 @@ import { useAppState } from '@/app/AppState';
 import { getSharePathFromShareModalProps, ShareModalProps } from '.';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useAppText } from '@/i18n/state/client';
 
 let prefetchedImage: HTMLImageElement | null = null;
 
@@ -26,6 +27,8 @@ export default function ShareButton({
 
   const router = useRouter();
 
+  const appText = useAppText();
+
   const absoluteImagePath = getSharePathFromShareModalProps({ ...rest });
 
   useEffect(() => {
@@ -35,9 +38,12 @@ export default function ShareButton({
     }
   }, [prefetch, absoluteImagePath, router]);
 
+  const tooltipText = tooltip ?? appText.tooltip.sharePhoto;
+
   return (
     <LoaderButton
-      tooltip={tooltip}
+      tooltip={tooltipText}
+      aria-label={tooltipText}
       onClick={() => setShareModalProps?.({ ...rest })}
       className={clsx(
         className,

--- a/src/utility/useScrollDirection.ts
+++ b/src/utility/useScrollDirection.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export default function useScrollDirection() {
   const [scrollInfo, setScrollInfo] = useState({
@@ -6,28 +6,35 @@ export default function useScrollDirection() {
     scrollY: 0,
   });
 
+  const isTickingRef = useRef(false);
+
   useEffect(() => {
     const handleScroll = () => {
-      const scrollY = window.scrollY;
-      const pageHeight = (
-        document.documentElement.scrollHeight -
-        window.innerHeight
-      );
-      setScrollInfo(prev => {
-        let scrollDirection = prev.scrollDirection;
-        if (scrollY !== prev.scrollY) {
-          scrollDirection = (
+      // Coalesce rapid-fire scroll events (e.g., mobile flick scrolling)
+      // into at most one state update per animation frame
+      if (isTickingRef.current) { return; }
+      isTickingRef.current = true;
+      requestAnimationFrame(() => {
+        isTickingRef.current = false;
+        const scrollY = window.scrollY;
+        const pageHeight = (
+          document.documentElement.scrollHeight -
+          window.innerHeight
+        );
+        setScrollInfo(prev => {
+          if (scrollY === prev.scrollY) { return prev; }
+          const scrollDirection = (
             scrollY > prev.scrollY ||
             prev.scrollY > pageHeight
           ) ? 'down' : 'up';
-        }
-        return {
-          scrollDirection,
-          scrollY,
-        };
+          return {
+            scrollDirection,
+            scrollY,
+          };
+        });
       });
     };
-    window.addEventListener('scroll', handleScroll);
+    window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 


### PR DESCRIPTION
## Summary

This PR fixes a mobile crash bug and closes several accessibility gaps found during a review of the codebase.

## Mobile fast-scroll crash

On mobile, fast scrolling could turn the page blank, then reload it back to the top. The cause was high load on the main thread and high memory use during infinite scroll.

- `useScrollDirection` now limits its scroll handler to one update per animation frame. Before this change, the handler ran on every scroll event with no limit.
- The masonry grid now skips render and paint work for tiles outside the screen, through `content-visibility`. Tile height still comes from `aspectRatio`, so this change does not affect layout.

## Hydration mismatch on "load more"

The infinite scroll "load more" button showed a React hydration warning. SWR's loading state can differ between the server-rendered pass and the first render on the client. This caused the button's `disabled` value to not match between server and client.

The fix defers the loading-based display value until after mount, through `useSyncExternalStore`. The first client render now matches the server. Pagination logic still uses the real value, so behavior does not change.

## Accessibility fixes

- **Keyboard access**: switcher items with a click handler but no link (theme switcher, view, sort, and search controls) rendered a plain `div` with an onClick handler. This made them unreachable by keyboard or screen reader. They now render a real `button`.
- **Accessible names**: icon-only buttons that relied only on a hover tooltip for their label (`CopyButton`, `DownloadButton`, `ShareButton`, and switcher items) now have an `aria-label`.
- **Focus ring**: `LoaderButton`'s `hideFocusOutline` option removed the focus ring for all users. It now removes the ring only for mouse clicks and keeps it for keyboard focus.
- **Landmarks**: the footer now renders as a `footer` element instead of a `div`.
- **Form validation**: `FieldsetWithStatus` now sets `required`, `aria-invalid`, and `aria-describedby` on fields with errors. `ErrorNote` now has `role="alert"`, so screen readers announce it when it appears.
- **Alt text**: two components used a raw upload URL or the fixed word "Upload" as alt text. They now use the file name or photo title.
- **Lint tooling**: added `eslint-plugin-jsx-a11y` with its recommended rules — the first dedicated accessibility lint tool in this project. The new rules found 16 further errors across 8 files: non-interactive elements with a click handler and no keyboard support. Each one was fixed on its own merit — converted to a real `button` where that was the right fix, redundant handlers removed where a native element already worked, and two intentional ARIA combobox patterns documented with a scoped `eslint-disable` and a comment explaining why.

## Test plan

- [ ] `pnpm lint` and `pnpm tsc --noEmit` pass with no errors
- [ ] Fast-scroll the homepage and `/grid` on a mobile device; confirm the page no longer goes blank or reloads
- [ ] Reload the homepage and confirm the hydration warning is gone from the browser console
- [ ] Tab through the theme switcher, view switcher, and sort/search controls with a keyboard only
- [ ] Confirm tooltip-only buttons (copy, download, share) have a visible accessible name in the accessibility tree
- [ ] Tab to a focused button that uses `hideFocusOutline` and confirm a visible focus ring appears
- [ ] Submit an admin form with a required field empty and confirm the error is announced by a screen reader