### PR TITLE
Fix mobile blank-reload crash on fast scrollFix mobile scroll crash

### DIFF
--- a/src/admin/edit-titles/EditTitlesProvider.tsx
+++ b/src/admin/edit-titles/EditTitlesProvider.tsx
@@ -133,7 +133,6 @@ export default function EditTitlesProvider({
 
   useEffect(() => {
     if (!isEditingTitles) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setPhotoEdits({});
       setIsPerformingUpdate(false);
     }

--- a/src/photo/InfinitePhotoScroll.tsx
+++ b/src/photo/InfinitePhotoScroll.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import useSwrInfinite from 'swr/infinite';
-import { ReactNode, useCallback, useMemo, useRef } from 'react';
+import {
+  ReactNode,
+  useCallback,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
 import AppGrid from '@/components/AppGrid';
 import Spinner from '@/components/Spinner';
 import { getPhotosCachedAction, getPhotosAction } from '@/photo/actions';
@@ -17,6 +23,12 @@ import { useAppText } from '@/i18n/state/client';
 const SIZE_KEY_SEPARATOR = '__';
 const getSizeFromKey = (key: string) =>
   parseInt(key.split(SIZE_KEY_SEPARATOR)[1]);
+
+// Used to defer client-only rendering until after mount without a
+// setState-in-effect cascading render (see useSyncExternalStore usage below)
+const subscribeNoop = () => () => {};
+const getSnapshotClient = () => true;
+const getSnapshotServer = () => false;
 
 export type RevalidatePhoto = (
   photoId: string,
@@ -67,7 +79,7 @@ export default function InfinitePhotoScroll({
   }) => ReactNode
 } & PhotoSetCategory) {
   const { isUserSignedIn } = useAppState();
-  
+
   const { utility } = useAppText();
 
   const keyGenerator = useCallback(
@@ -83,7 +95,7 @@ export default function InfinitePhotoScroll({
   ) =>
     (useCachedPhotos ? getPhotosCachedAction : getPhotosAction)({
       offset: initialOffset + getSizeFromKey(keyWithSize) * itemsPerPage,
-      sortBy, 
+      sortBy,
       sortWithPriority,
       excludeFromFeeds,
       limit: itemsPerPage,
@@ -130,8 +142,19 @@ export default function InfinitePhotoScroll({
     );
 
   const buttonContainerRef = useRef<HTMLDivElement>(null);
-  
+
   const isLoadingOrValidating = isLoading || isValidating;
+
+  // SWR's loading state can differ between the server-rendered pass and the
+  // client's first hydration pass, causing a hydration mismatch on the
+  // "load more" button below. useSyncExternalStore lets the server and
+  // client intentionally diverge here without triggering that mismatch.
+  const hasMounted = useSyncExternalStore(
+    subscribeNoop,
+    getSnapshotClient,
+    getSnapshotServer,
+  );
+  const isLoadingOrValidatingForDisplay = hasMounted && isLoadingOrValidating;
 
   const isFinished = useMemo(() =>
     data && data[data.length - 1]?.length < itemsPerPage
@@ -161,15 +184,15 @@ export default function InfinitePhotoScroll({
       <button
         type="button"
         onClick={() => error ? mutate() : advance()}
-        disabled={isLoading || isValidating}
+        disabled={isLoadingOrValidatingForDisplay}
         className={clsx(
           'w-full flex justify-center',
-          isLoadingOrValidating && 'subtle',
+          isLoadingOrValidatingForDisplay && 'subtle',
         )}
       >
         {error
           ? utility.tryAgain
-          : isLoadingOrValidating
+          : isLoadingOrValidatingForDisplay
             ? <Spinner size={20} />
             : utility.loadMore}
       </button>

--- a/src/photo/PhotoGrid.tsx
+++ b/src/photo/PhotoGrid.tsx
@@ -72,6 +72,9 @@ export default function PhotoGrid({
       style={{
         ...(MASONRY_GRID_ENABLED) ? {
           aspectRatio: photo.aspectRatio,
+          // Skip render/paint work for tiles scrolled off-screen — height
+          // stays derived from aspectRatio, so this doesn't affect layout
+          contentVisibility: 'auto',
         } : (GRID_ASPECT_RATIO !== 0) ? {
           aspectRatio: GRID_ASPECT_RATIO,
         } : {},

--- a/src/utility/useScrollDirection.ts
+++ b/src/utility/useScrollDirection.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export default function useScrollDirection() {
   const [scrollInfo, setScrollInfo] = useState({
@@ -6,28 +6,35 @@ export default function useScrollDirection() {
     scrollY: 0,
   });
 
+  const isTickingRef = useRef(false);
+
   useEffect(() => {
     const handleScroll = () => {
-      const scrollY = window.scrollY;
-      const pageHeight = (
-        document.documentElement.scrollHeight -
-        window.innerHeight
-      );
-      setScrollInfo(prev => {
-        let scrollDirection = prev.scrollDirection;
-        if (scrollY !== prev.scrollY) {
-          scrollDirection = (
+      // Coalesce rapid-fire scroll events (e.g., mobile flick scrolling)
+      // into at most one state update per animation frame
+      if (isTickingRef.current) { return; }
+      isTickingRef.current = true;
+      requestAnimationFrame(() => {
+        isTickingRef.current = false;
+        const scrollY = window.scrollY;
+        const pageHeight = (
+          document.documentElement.scrollHeight -
+          window.innerHeight
+        );
+        setScrollInfo(prev => {
+          if (scrollY === prev.scrollY) { return prev; }
+          const scrollDirection = (
             scrollY > prev.scrollY ||
             prev.scrollY > pageHeight
           ) ? 'down' : 'up';
-        }
-        return {
-          scrollDirection,
-          scrollY,
-        };
+          return {
+            scrollDirection,
+            scrollY,
+          };
+        });
       });
     };
-    window.addEventListener('scroll', handleScroll);
+    window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 

--- a/src/utility/useScrollDirection.ts
+++ b/src/utility/useScrollDirection.ts
@@ -7,6 +7,7 @@ export default function useScrollDirection() {
   });
 
   const isTickingRef = useRef(false);
+  const rafRef = useRef<number>(undefined);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -14,7 +15,7 @@ export default function useScrollDirection() {
       // into at most one state update per animation frame
       if (isTickingRef.current) { return; }
       isTickingRef.current = true;
-      requestAnimationFrame(() => {
+      rafRef.current = requestAnimationFrame(() => {
         isTickingRef.current = false;
         const scrollY = window.scrollY;
         const pageHeight = (
@@ -35,7 +36,12 @@ export default function useScrollDirection() {
       });
     };
     window.addEventListener('scroll', handleScroll, { passive: true });
-    return () => window.removeEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (rafRef.current !== undefined) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
   }, []);
 
   return scrollInfo;


### PR DESCRIPTION
## Summary

Fast scrolling on mobile can turn the page blank, then reload it back to the top. This happens because of high load on the main thread and high memory use during infinite scroll. This PR reduces that load and also fixes a hydration mismatch on the "load more" button.

## Mobile fast-scroll crash

The scroll handler in `useScrollDirection` ran on every scroll event, with no limit. It now runs once per animation frame.

The masonry grid now skips render and paint work for tiles outside the screen. It does this through `content-visibility`. Tile height still comes from `aspectRatio`, so this change does not affect layout.

## Hydration mismatch on "load more"

The infinite scroll "load more" button showed a React hydration warning. SWR's loading state can differ between the server-rendered pass and the first render on the client. As a result, the button's `disabled` value did not match between server and client.

The fix defers the loading-based display value until after mount. It uses `useSyncExternalStore` for this. The first client render now matches the server. Pagination logic still uses the real value, so behavior does not change.

Note: I found this issue while I tested the scroll fix on my local machine. I have not tried to reproduce it in production yet.

## Test plan

- [ ] Run `pnpm lint` and `pnpm tsc --noEmit`. Both must pass with no errors.
- [ ] Fast-scroll the homepage and `/grid` on a mobile device. The page must not go blank or reload.
- [ ] Reload the homepage. The hydration warning must not appear in the browser console.