### PR TITLE
fix(utility): guard undefined exifr in getDimensionsFromExif

### DIFF
--- a/__tests__/exif.test.ts
+++ b/__tests__/exif.test.ts
@@ -1,10 +1,50 @@
-import { convertApertureValueToFNumber } from '@/utility/exif';
+import {
+  convertApertureValueToFNumber,
+  getDimensionsFromExif,
+} from '@/utility/exif';
+import { OrientationTypes } from 'ts-exif-parser';
 import {
   formatExposureTime,
   formatExposureCompensation,
 } from '@/utility/exif-format';
 
 describe('EXIF', () => {
+  describe('dimensions from exif', () => {
+    it('fall back to DEFAULT_ASPECT_RATIO when exifr is undefined', () => {
+      // Regression: HEIC uploads can reach a partial parse where exifr is
+      // undefined; previously `exifr.ImageWidth` threw a TypeError.
+      const { width, height, aspectRatio } = getDimensionsFromExif(
+        { tags: {}, imageSize: undefined } as any,
+        undefined,
+      );
+      expect(width).toBeUndefined();
+      expect(height).toBeUndefined();
+      expect(aspectRatio).toBe(1.5); // DEFAULT_ASPECT_RATIO
+    });
+
+    it('use imageSize when present even if exifr is undefined', () => {
+      const { width, height, aspectRatio } = getDimensionsFromExif(
+        {
+          tags: { Orientation: OrientationTypes.TOP_LEFT },
+          imageSize: { width: 4032, height: 3024 } as any,
+        } as any,
+        undefined,
+      );
+      expect(width).toBe(4032);
+      expect(height).toBe(3024);
+      expect(aspectRatio).toBeCloseTo(4 / 3);
+    });
+
+    it('use exifr ImageWidth/Height as fallback when imageSize missing', () => {
+      const { width, height, aspectRatio } = getDimensionsFromExif(
+        { tags: { Orientation: OrientationTypes.TOP_LEFT } } as any,
+        { ImageWidth: 1200, ImageHeight: 800 },
+      );
+      expect(width).toBe(1200);
+      expect(height).toBe(800);
+      expect(aspectRatio).toBeCloseTo(1.5);
+    });
+  });
   describe('converts', () => {
     it('aperture value to f-number', () => {
       expect(convertApertureValueToFNumber('0')).toBe('1');

--- a/src/utility/exif.ts
+++ b/src/utility/exif.ts
@@ -31,6 +31,9 @@ export const getDimensionsFromExif = (
   // Using '||' operator to handle `Orientation` unexpectedly being '0'
   const orientation = exif.tags?.Orientation || OrientationTypes.TOP_LEFT;
 
+  const exifrImageWidth = exifr?.ImageWidth;
+  const exifrImageHeight = exifr?.ImageHeight;
+
   let width: number | undefined;
   let height: number | undefined;
 
@@ -41,13 +44,13 @@ export const getDimensionsFromExif = (
     case OrientationTypes.BOTTOM_LEFT:
     case OrientationTypes.LEFT_TOP:
     case OrientationTypes.RIGHT_BOTTOM:
-      width = exif.imageSize?.width || exifr.ImageWidth;
-      height = exif.imageSize?.height || exifr.ImageHeight;
+      width = exif.imageSize?.width || exifrImageWidth;
+      height = exif.imageSize?.height || exifrImageHeight;
       break;
     case OrientationTypes.RIGHT_TOP:
     case OrientationTypes.LEFT_BOTTOM:
-      width = exif.imageSize?.height || exifr.ImageHeight;
-      height = exif.imageSize?.width || exifr.ImageWidth;
+      width = exif.imageSize?.height || exifrImageHeight;
+      height = exif.imageSize?.width || exifrImageWidth;
       break;
   }
 


### PR DESCRIPTION
## Bug fix: guard undefined `exifr` in `getDimensionsFromExif`

### Describe the bug

Uploading a **HEIC** file (which `sharp`/`next/image` do not support) through the `/admin/uploads/[uploadPath]` route causes a server-side **500 error**:

```
TypeError: Cannot read properties of undefined (reading 'ImageWidth')
```

The failure is triggered by a *partial* EXIF parse: `ts-exif-parser` is able to read the container, but `exifr.parse()` throws `"Unknown file format"` on HEIC input. This leaves `exifr` as `undefined`, and the subsequent call into `convertExifToFormData(dataExif, dataExifr, ...)` dereferences `exifr.ImageWidth` in `getDimensionsFromExif`, crashing the page instead of rendering the existing `ErrorNote` fallback.

### Root cause

In `src/utility/exif.ts`, `getDimensionsFromExif` reads `exifr.ImageWidth` / `exifr.ImageHeight` without guarding against `exifr` being `undefined`:

```ts
width = exif.imageSize?.width || exifr.ImageWidth;
height = exif.imageSize?.height || exifr.ImageHeight;
```

When a partial parse yields `exifr === undefined` (HEIC, or any format `exifr` can't fully parse), this throws an uncaught `TypeError`.

### Fix

Hoist the `exifr` reads behind optional chaining so `exifr` being `undefined` can never crash:

```ts
const exifrImageWidth = exifr?.ImageWidth;
const exifrImageHeight = exifr?.ImageHeight;
```

The function now degrades gracefully — `width`/`height` are `undefined`, and the caller falls through to the default aspect ratio / `ErrorNote` path instead of 500ing. The `error` that was already being captured in `extractImageDataFromBlobPath` is now reachable.

### Files changed

- `src/utility/exif.ts` — guard `exifr` access in `getDimensionsFromExif`
- `__tests__/exif.test.ts` — regression tests covering: undefined `exifr`, `imageSize`-present fallback, and `exifr`-as-fallback branches

### Tests

- `npx jest __tests__/exif.test.ts` → **6/6 pass**
- `npx eslint __tests__/exif.test.ts src/utility/exif.ts` → **0 errors, 0 warnings**
- `npx tsc --noEmit` → **no type errors**

### Notes for the maintainer

This fixes the **crash** for HEIC uploads so the page no longer 500s (it now renders the existing error/fallback). It does not add HEIC rendering support, that remains out of scope per the README (sharp/next/image don't support HEIC), and Apple's native share flows still auto-convert HEIC→JPG.